### PR TITLE
Make append work also when passing a simple string

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,14 @@ jobs:
     <<: *defaults
     steps:
       - checkout
+      - run:
+          name: install dockerize
+          command: wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && sudo tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+          environment:
+            DOCKERIZE_VERSION: v0.6.1
+      - run:
+          name: Wait for db
+          command: dockerize -wait tcp://127.0.0.1:5432 -timeout 1m
       # Download and cache dependencies
       - run: npm install
       - persist_to_workspace:

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ npm install @nearform/sql
 ```
 
 ## Usage
+
 ```js
 const SQL = require('@nearform/sql')
 
@@ -53,13 +54,14 @@ sql`SELECT 1`
 ```
 
 ## Methods
-### append(statement)
+### append(statement[, options])
 ```js
 const username = 'user1'
 const email = 'user1@email.com'
 const userId = 1
 
 const sql = SQL`UPDATE users SET name = ${username}, email = ${email} `
+sql.append(SQL`SET ${dynamicName} = '2'`, { unsafe: true })
 sql.append(SQL`WHERE id = ${userId}`)
 ```
 
@@ -104,7 +106,7 @@ npm run lint            # lints via standardJS.
 Find more about `@nearform/sql` speed [here](benchmark)
 
 # License
-Copyright nearForm 2018. Licensed under 
+Copyright nearForm 2018. Licensed under
 [Apache 2.0](<https://tldrlegal.com/license/apache-license-2.0-(apache-2.0)>)
 
 [1]: https://img.shields.io/npm/v/@nearform/sql.svg?style=flat-square

--- a/SQL.js
+++ b/SQL.js
@@ -45,6 +45,16 @@ class SqlStatement {
   }
 
   append (statement) {
+    if (!statement) {
+      return this
+    }
+
+    if (!(statement instanceof SqlStatement)) {
+      this.strings[this.strings.length - 1] += statement
+
+      return this
+    }
+
     const last = this.strings[this.strings.length - 1]
     const [first, ...rest] = statement.strings
 

--- a/SQL.js
+++ b/SQL.js
@@ -1,5 +1,5 @@
 class SqlStatement {
-  constructor (strings, values) {
+  constructor (strings, values, expression) {
     this.strings = strings
     this.values = values
   }
@@ -44,13 +44,25 @@ class SqlStatement {
     return text.replace(/^\s+|\s+$/mg, '')
   }
 
-  append (statement) {
+  append (statement, options) {
     if (!statement) {
       return this
     }
 
     if (!(statement instanceof SqlStatement)) {
-      this.strings[this.strings.length - 1] += statement
+      throw new Error('"append" accept only template string prefixed with SQL (SQL`...`)')
+    }
+
+    if (options && options.unsafe === true) {
+      const text = statement.strings.reduce((acc, string, i) => {
+        acc = `${acc}${string}${statement.values[i] ? statement.values[i] : ''}`
+        return acc
+      }, '')
+
+      const strings = this.strings.slice(0)
+      strings[this.strings.length - 1] += text
+
+      this.strings = strings
 
       return this
     }

--- a/SQL.js
+++ b/SQL.js
@@ -1,5 +1,5 @@
 class SqlStatement {
-  constructor (strings, values, expression) {
+  constructor (strings, values) {
     this.strings = strings
     this.values = values
   }
@@ -50,7 +50,7 @@ class SqlStatement {
     }
 
     if (!(statement instanceof SqlStatement)) {
-      throw new Error('"append" accept only template string prefixed with SQL (SQL`...`)')
+      throw new Error('"append" accepts only template string prefixed with SQL (SQL`...`)')
     }
 
     if (options && options.unsafe === true) {

--- a/SQL.test.js
+++ b/SQL.test.js
@@ -100,3 +100,28 @@ test('SQL helper - build complex query with append', (t) => {
   t.deepEqual(sql.values, [v1, v2, v3, v4, v5, v6, v7])
   t.end()
 })
+
+test('SQL helper - build complex query with append passing simple strings and template strings', (t) => {
+  const v1 = 'v1'
+  const v2 = 'v2'
+  const v3 = 'v3'
+  const v4 = 'v4'
+  const v5 = 'v5'
+  const v6 = 'v6'
+  const v7 = 'v7'
+
+  const sql = SQL`TEST QUERY glue pieces FROM `
+  sql.append(SQL`v1 = ${v1}, `)
+  sql.append(SQL`v2 = ${v2}, `)
+  sql.append(SQL`v3 = ${v3}, `)
+  sql.append(SQL`v4 = ${v4}, `)
+  sql.append(SQL`v5 = ${v5}, `)
+  sql.append(`v6 = v6 `)
+  sql.append(SQL`WHERE v6 = ${v6} `)
+  sql.append(SQL`AND v7 = ${v7} `)
+  sql.append(`AND v8 = v8`)
+
+  t.equal(sql.text, 'TEST QUERY glue pieces FROM v1 = $1, v2 = $2, v3 = $3, v4 = $4, v5 = $5, v6 = v6 WHERE v6 = $6 AND v7 = $7 AND v8 = v8')
+  t.deepEqual(sql.values, [v1, v2, v3, v4, v5, v6, v7])
+  t.end()
+})

--- a/SQL.test.js
+++ b/SQL.test.js
@@ -132,7 +132,7 @@ test('SQL helper - will throw an error if append is called without using SQL', (
     sql.append(`v1 = v1`)
     t.fail('showld throw an error when passing strings not prefixed with SQL')
   } catch (e) {
-    t.equal(e.message, '"append" accept only template string prefixed with SQL (SQL`...`)')
+    t.equal(e.message, '"append" accepts only template string prefixed with SQL (SQL`...`)')
   }
   t.end()
 })

--- a/SQL.test.js
+++ b/SQL.test.js
@@ -116,12 +116,54 @@ test('SQL helper - build complex query with append passing simple strings and te
   sql.append(SQL`v3 = ${v3}, `)
   sql.append(SQL`v4 = ${v4}, `)
   sql.append(SQL`v5 = ${v5}, `)
-  sql.append(`v6 = v6 `)
+  sql.append(SQL`v6 = v6 `)
   sql.append(SQL`WHERE v6 = ${v6} `)
   sql.append(SQL`AND v7 = ${v7} `)
-  sql.append(`AND v8 = v8`)
+  sql.append(SQL`AND v8 = v8`)
 
   t.equal(sql.text, 'TEST QUERY glue pieces FROM v1 = $1, v2 = $2, v3 = $3, v4 = $4, v5 = $5, v6 = v6 WHERE v6 = $6 AND v7 = $7 AND v8 = v8')
   t.deepEqual(sql.values, [v1, v2, v3, v4, v5, v6, v7])
+  t.end()
+})
+
+test('SQL helper - will throw an error if append is called without using SQL', (t) => {
+  const sql = SQL`TEST QUERY glue pieces FROM `
+  try {
+    sql.append(`v1 = v1`)
+    t.fail('showld throw an error when passing strings not prefixed with SQL')
+  } catch (e) {
+    t.equal(e.message, '"append" accept only template string prefixed with SQL (SQL`...`)')
+  }
+  t.end()
+})
+
+test('SQL helper - build string using append with and without unsafe flag', (t) => {
+  const v2 = 'v2'
+  const longName = 'whateverThisIs'
+  const sql = SQL`TEST QUERY glue pieces FROM test WHERE test1 == test2`
+  sql.append(SQL` AND v1 = v1,`)
+  sql.append(SQL` AND v2 = ${v2}, `)
+  sql.append(SQL` AND v3 = ${longName}`, { unsafe: true })
+  sql.append(SQL` AND v4 = v4`, { unsafe: true })
+
+  t.equal(sql.text, 'TEST QUERY glue pieces FROM test WHERE test1 == test2 AND v1 = v1, AND v2 = $1,  AND v3 = whateverThisIs AND v4 = v4')
+  t.equal(sql.values.length, 1)
+  t.true(sql.values.includes(v2))
+  t.end()
+})
+
+test('SQL helper - build string using append and only unsafe', (t) => {
+  const v2 = 'v2'
+  const longName = 'whateverThisIs'
+
+  const sql = SQL`TEST QUERY glue pieces FROM test WHERE test1 == test2`
+  t.equal(sql.text, 'TEST QUERY glue pieces FROM test WHERE test1 == test2')
+
+  sql.append(SQL` AND v1 = v1,`, { unsafe: true })
+  t.equal(sql.text, 'TEST QUERY glue pieces FROM test WHERE test1 == test2 AND v1 = v1,')
+
+  sql.append(SQL` AND v2 = ${v2} AND v3 = ${longName} AND v4 = 'v4'`, { unsafe: true })
+  t.equal(sql.text, 'TEST QUERY glue pieces FROM test WHERE test1 == test2 AND v1 = v1, AND v2 = v2 AND v3 = whateverThisIs AND v4 = \'v4\'')
+
   t.end()
 })


### PR DESCRIPTION
Hi there,
this PR should allow for simple strings to be passed to `append`. As of now, `append` will only work if passed a template string with at least one parameter in it.

If passed something like 

```
append(`my simple string`)
```

it will return an error

```
statement.strings is not iterable
```

This PR will allow people to pass in strings or template strings without using the `SQL` prefix.
This could be useful in those cases where one wants to use dynamic values in the query, but not as arguments

```javascript 
// ...
const dynamicTableName = 'test'

const sql = SQL`INSERT INTO `
sql.append(`${dynamicTableName} (...) VALUES `) // <== not using SQL
sql.append(SQL`(${v1}, ${v2}, ...)`)

// ...
```

Let me know if this make sense or if there is need of changing anything in this PR.

Thanks!