### PR TITLE
Add ORACLE support, split generators into different tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 node_modules
 
 package-lock.json
+yarn.lock

--- a/MYSQL.test.js
+++ b/MYSQL.test.js
@@ -1,0 +1,169 @@
+const test = require('tap').test
+
+const { MYSQL } = require('./SQL')
+
+test('SQL helper - build complex query with append', (t) => {
+  const name = 'Team 5'
+  const description = 'description'
+  const teamId = 7
+  const organizationId = 'WONKA'
+
+  const sql = MYSQL`UPDATE teams SET name = ${name}, description = ${description} `
+  sql.append(MYSQL`WHERE id = ${teamId} AND org_id = ${organizationId}`)
+
+  t.equal(sql.text, 'UPDATE teams SET name = ?, description = ? WHERE id = ? AND org_id = ?')
+  t.deepEqual(sql.values, [name, description, teamId, organizationId])
+  t.end()
+})
+
+test('SQL helper - multiline', (t) => {
+  const name = 'Team 5'
+  const description = 'description'
+  const teamId = 7
+  const organizationId = 'WONKA'
+
+  const sql = MYSQL`
+    UPDATE teams SET name = ${name}, description = ${description}
+    WHERE id = ${teamId} AND org_id = ${organizationId}
+  `
+
+  t.equal(sql.text, 'UPDATE teams SET name = ?, description = ?\nWHERE id = ? AND org_id = ?')
+  t.deepEqual(sql.values, [name, description, teamId, organizationId])
+  t.end()
+})
+
+test('SQL helper - build complex query with glue', (t) => {
+  const name = 'Team 5'
+  const description = 'description'
+  const teamId = 7
+  const organizationId = 'WONKA'
+
+  const sql = MYSQL` UPDATE teams SET `
+
+  const updates = []
+  updates.push(MYSQL`name = ${name}`)
+  updates.push(MYSQL`description = ${description}`)
+
+  sql.append(sql.glue(updates, ' , '))
+  sql.append(MYSQL`WHERE id = ${teamId} AND org_id = ${organizationId}`)
+
+  t.equal(sql.text, 'UPDATE teams SET name = ? , description = ? WHERE id = ? AND org_id = ?')
+  t.deepEqual(sql.values, [name, description, teamId, organizationId])
+  t.end()
+})
+
+test('SQL helper - build complex query with append and glue', (t) => {
+  const updates = []
+  const v1 = 'v1'
+  const v2 = 'v2'
+  const v3 = 'v3'
+  const v4 = 'v4'
+  const v5 = 'v5'
+  const v6 = 'v6'
+  const v7 = 'v7'
+
+  const sql = MYSQL`TEST QUERY glue pieces FROM `
+  updates.push(MYSQL`v1 = ${v1}`)
+  updates.push(MYSQL`v2 = ${v2}`)
+  updates.push(MYSQL`v3 = ${v3}`)
+  updates.push(MYSQL`v4 = ${v4}`)
+  updates.push(MYSQL`v5 = ${v5}`)
+
+  sql.append(sql.glue(updates, ' , '))
+  sql.append(MYSQL`WHERE v6 = ${v6} `)
+  sql.append(MYSQL`AND v7 = ${v7}`)
+
+  t.equal(sql.text, 'TEST QUERY glue pieces FROM v1 = ? , v2 = ? , v3 = ? , v4 = ? , v5 = ? WHERE v6 = ? AND v7 = ?')
+  t.deepEqual(sql.values, [v1, v2, v3, v4, v5, v6, v7])
+  t.end()
+})
+
+test('SQL helper - build complex query with append', (t) => {
+  const v1 = 'v1'
+  const v2 = 'v2'
+  const v3 = 'v3'
+  const v4 = 'v4'
+  const v5 = 'v5'
+  const v6 = 'v6'
+  const v7 = 'v7'
+
+  const sql = MYSQL`TEST QUERY glue pieces FROM `
+  sql.append(MYSQL`v1 = ${v1}, `)
+  sql.append(MYSQL`v2 = ${v2}, `)
+  sql.append(MYSQL`v3 = ${v3}, `)
+  sql.append(MYSQL`v4 = ${v4}, `)
+  sql.append(MYSQL`v5 = ${v5} `)
+  sql.append(MYSQL`WHERE v6 = ${v6} `)
+  sql.append(MYSQL`AND v7 = ${v7}`)
+
+  t.equal(sql.text, 'TEST QUERY glue pieces FROM v1 = ?, v2 = ?, v3 = ?, v4 = ?, v5 = ? WHERE v6 = ? AND v7 = ?')
+  t.deepEqual(sql.values, [v1, v2, v3, v4, v5, v6, v7])
+  t.end()
+})
+
+test('SQL helper - build complex query with append passing simple strings and template strings', (t) => {
+  const v1 = 'v1'
+  const v2 = 'v2'
+  const v3 = 'v3'
+  const v4 = 'v4'
+  const v5 = 'v5'
+  const v6 = 'v6'
+  const v7 = 'v7'
+
+  const sql = MYSQL`TEST QUERY glue pieces FROM `
+  sql.append(MYSQL`v1 = ${v1}, `)
+  sql.append(MYSQL`v2 = ${v2}, `)
+  sql.append(MYSQL`v3 = ${v3}, `)
+  sql.append(MYSQL`v4 = ${v4}, `)
+  sql.append(MYSQL`v5 = ${v5}, `)
+  sql.append(MYSQL`v6 = v6 `)
+  sql.append(MYSQL`WHERE v6 = ${v6} `)
+  sql.append(MYSQL`AND v7 = ${v7} `)
+  sql.append(MYSQL`AND v8 = v8`)
+
+  t.equal(sql.text, 'TEST QUERY glue pieces FROM v1 = ?, v2 = ?, v3 = ?, v4 = ?, v5 = ?, v6 = v6 WHERE v6 = ? AND v7 = ? AND v8 = v8')
+  t.deepEqual(sql.values, [v1, v2, v3, v4, v5, v6, v7])
+  t.end()
+})
+
+test('SQL helper - will throw an error if append is called without using SQL', (t) => {
+  const sql = MYSQL`TEST QUERY glue pieces FROM `
+  try {
+    sql.append(`v1 = v1`)
+    t.fail('should throw an error when passing strings not prefixed with MYSQL')
+  } catch (e) {
+    t.equal(e.message, '"append" accepts only template string prefixed with PG/MYSQL/ORACLE (PG`...`)')
+  }
+  t.end()
+})
+
+test('SQL helper - build string using append with and without unsafe flag', (t) => {
+  const v2 = 'v2'
+  const longName = 'whateverThisIs'
+  const sql = MYSQL`TEST QUERY glue pieces FROM test WHERE test1 == test2`
+  sql.append(MYSQL` AND v1 = v1,`)
+  sql.append(MYSQL` AND v2 = ${v2}, `)
+  sql.append(MYSQL` AND v3 = ${longName}`, { unsafe: true })
+  sql.append(MYSQL` AND v4 = v4`, { unsafe: true })
+
+  t.equal(sql.text, 'TEST QUERY glue pieces FROM test WHERE test1 == test2 AND v1 = v1, AND v2 = ?,  AND v3 = whateverThisIs AND v4 = v4')
+  t.equal(sql.values.length, 1)
+  t.true(sql.values.includes(v2))
+  t.end()
+})
+
+test('SQL helper - build string using append and only unsafe', (t) => {
+  const v2 = 'v2'
+  const longName = 'whateverThisIs'
+
+  const sql = MYSQL`TEST QUERY glue pieces FROM test WHERE test1 == test2`
+  t.equal(sql.text, 'TEST QUERY glue pieces FROM test WHERE test1 == test2')
+
+  sql.append(MYSQL` AND v1 = v1,`, { unsafe: true })
+  t.equal(sql.text, 'TEST QUERY glue pieces FROM test WHERE test1 == test2 AND v1 = v1,')
+
+  sql.append(MYSQL` AND v2 = ${v2} AND v3 = ${longName} AND v4 = 'v4'`, { unsafe: true })
+  t.equal(sql.text, 'TEST QUERY glue pieces FROM test WHERE test1 == test2 AND v1 = v1, AND v2 = v2 AND v3 = whateverThisIs AND v4 = \'v4\'')
+
+  t.end()
+})

--- a/ORACLE.test.js
+++ b/ORACLE.test.js
@@ -1,0 +1,169 @@
+const test = require('tap').test
+
+const { ORACLE } = require('./SQL')
+
+test('SQL helper - build complex query with append', (t) => {
+  const name = 'Team 5'
+  const description = 'description'
+  const teamId = 7
+  const organizationId = 'WONKA'
+
+  const sql = ORACLE`UPDATE teams SET name = ${name}, description = ${description} `
+  sql.append(ORACLE`WHERE id = ${teamId} AND org_id = ${organizationId}`)
+
+  t.equal(sql.text, 'UPDATE teams SET name = :1, description = :2 WHERE id = :3 AND org_id = :4')
+  t.deepEqual(sql.values, [name, description, teamId, organizationId])
+  t.end()
+})
+
+test('SQL helper - multiline', (t) => {
+  const name = 'Team 5'
+  const description = 'description'
+  const teamId = 7
+  const organizationId = 'WONKA'
+
+  const sql = ORACLE`
+    UPDATE teams SET name = ${name}, description = ${description}
+    WHERE id = ${teamId} AND org_id = ${organizationId}
+  `
+
+  t.equal(sql.text, 'UPDATE teams SET name = :1, description = :2\nWHERE id = :3 AND org_id = :4')
+  t.deepEqual(sql.values, [name, description, teamId, organizationId])
+  t.end()
+})
+
+test('SQL helper - build complex query with glue', (t) => {
+  const name = 'Team 5'
+  const description = 'description'
+  const teamId = 7
+  const organizationId = 'WONKA'
+
+  const sql = ORACLE` UPDATE teams SET `
+
+  const updates = []
+  updates.push(ORACLE`name = ${name}`)
+  updates.push(ORACLE`description = ${description}`)
+
+  sql.append(sql.glue(updates, ' , '))
+  sql.append(ORACLE`WHERE id = ${teamId} AND org_id = ${organizationId}`)
+
+  t.equal(sql.text, 'UPDATE teams SET name = :1 , description = :2 WHERE id = :3 AND org_id = :4')
+  t.deepEqual(sql.values, [name, description, teamId, organizationId])
+  t.end()
+})
+
+test('SQL helper - build complex query with append and glue', (t) => {
+  const updates = []
+  const v1 = 'v1'
+  const v2 = 'v2'
+  const v3 = 'v3'
+  const v4 = 'v4'
+  const v5 = 'v5'
+  const v6 = 'v6'
+  const v7 = 'v7'
+
+  const sql = ORACLE`TEST QUERY glue pieces FROM `
+  updates.push(ORACLE`v1 = ${v1}`)
+  updates.push(ORACLE`v2 = ${v2}`)
+  updates.push(ORACLE`v3 = ${v3}`)
+  updates.push(ORACLE`v4 = ${v4}`)
+  updates.push(ORACLE`v5 = ${v5}`)
+
+  sql.append(sql.glue(updates, ' , '))
+  sql.append(ORACLE`WHERE v6 = ${v6} `)
+  sql.append(ORACLE`AND v7 = ${v7}`)
+
+  t.equal(sql.text, 'TEST QUERY glue pieces FROM v1 = :1 , v2 = :2 , v3 = :3 , v4 = :4 , v5 = :5 WHERE v6 = :6 AND v7 = :7')
+  t.deepEqual(sql.values, [v1, v2, v3, v4, v5, v6, v7])
+  t.end()
+})
+
+test('SQL helper - build complex query with append', (t) => {
+  const v1 = 'v1'
+  const v2 = 'v2'
+  const v3 = 'v3'
+  const v4 = 'v4'
+  const v5 = 'v5'
+  const v6 = 'v6'
+  const v7 = 'v7'
+
+  const sql = ORACLE`TEST QUERY glue pieces FROM `
+  sql.append(ORACLE`v1 = ${v1}, `)
+  sql.append(ORACLE`v2 = ${v2}, `)
+  sql.append(ORACLE`v3 = ${v3}, `)
+  sql.append(ORACLE`v4 = ${v4}, `)
+  sql.append(ORACLE`v5 = ${v5} `)
+  sql.append(ORACLE`WHERE v6 = ${v6} `)
+  sql.append(ORACLE`AND v7 = ${v7}`)
+
+  t.equal(sql.text, 'TEST QUERY glue pieces FROM v1 = :1, v2 = :2, v3 = :3, v4 = :4, v5 = :5 WHERE v6 = :6 AND v7 = :7')
+  t.deepEqual(sql.values, [v1, v2, v3, v4, v5, v6, v7])
+  t.end()
+})
+
+test('SQL helper - build complex query with append passing simple strings and template strings', (t) => {
+  const v1 = 'v1'
+  const v2 = 'v2'
+  const v3 = 'v3'
+  const v4 = 'v4'
+  const v5 = 'v5'
+  const v6 = 'v6'
+  const v7 = 'v7'
+
+  const sql = ORACLE`TEST QUERY glue pieces FROM `
+  sql.append(ORACLE`v1 = ${v1}, `)
+  sql.append(ORACLE`v2 = ${v2}, `)
+  sql.append(ORACLE`v3 = ${v3}, `)
+  sql.append(ORACLE`v4 = ${v4}, `)
+  sql.append(ORACLE`v5 = ${v5}, `)
+  sql.append(ORACLE`v6 = v6 `)
+  sql.append(ORACLE`WHERE v6 = ${v6} `)
+  sql.append(ORACLE`AND v7 = ${v7} `)
+  sql.append(ORACLE`AND v8 = v8`)
+
+  t.equal(sql.text, 'TEST QUERY glue pieces FROM v1 = :1, v2 = :2, v3 = :3, v4 = :4, v5 = :5, v6 = v6 WHERE v6 = :6 AND v7 = :7 AND v8 = v8')
+  t.deepEqual(sql.values, [v1, v2, v3, v4, v5, v6, v7])
+  t.end()
+})
+
+test('SQL helper - will throw an error if append is called without using SQL', (t) => {
+  const sql = ORACLE`TEST QUERY glue pieces FROM `
+  try {
+    sql.append(`v1 = v1`)
+    t.fail('should throw an error when passing strings not prefixed with ORACLE')
+  } catch (e) {
+    t.equal(e.message, '"append" accepts only template string prefixed with PG/MYSQL/ORACLE (PG`...`)')
+  }
+  t.end()
+})
+
+test('SQL helper - build string using append with and without unsafe flag', (t) => {
+  const v2 = 'v2'
+  const longName = 'whateverThisIs'
+  const sql = ORACLE`TEST QUERY glue pieces FROM test WHERE test1 == test2`
+  sql.append(ORACLE` AND v1 = v1,`)
+  sql.append(ORACLE` AND v2 = ${v2}, `)
+  sql.append(ORACLE` AND v3 = ${longName}`, { unsafe: true })
+  sql.append(ORACLE` AND v4 = v4`, { unsafe: true })
+
+  t.equal(sql.text, 'TEST QUERY glue pieces FROM test WHERE test1 == test2 AND v1 = v1, AND v2 = :1,  AND v3 = whateverThisIs AND v4 = v4')
+  t.equal(sql.values.length, 1)
+  t.true(sql.values.includes(v2))
+  t.end()
+})
+
+test('SQL helper - build string using append and only unsafe', (t) => {
+  const v2 = 'v2'
+  const longName = 'whateverThisIs'
+
+  const sql = ORACLE`TEST QUERY glue pieces FROM test WHERE test1 == test2`
+  t.equal(sql.text, 'TEST QUERY glue pieces FROM test WHERE test1 == test2')
+
+  sql.append(ORACLE` AND v1 = v1,`, { unsafe: true })
+  t.equal(sql.text, 'TEST QUERY glue pieces FROM test WHERE test1 == test2 AND v1 = v1,')
+
+  sql.append(ORACLE` AND v2 = ${v2} AND v3 = ${longName} AND v4 = 'v4'`, { unsafe: true })
+  t.equal(sql.text, 'TEST QUERY glue pieces FROM test WHERE test1 == test2 AND v1 = v1, AND v2 = v2 AND v3 = whateverThisIs AND v4 = \'v4\'')
+
+  t.end()
+})

--- a/PG.test.js
+++ b/PG.test.js
@@ -1,6 +1,6 @@
 const test = require('tap').test
 
-const SQL = require('./SQL')
+const { PG } = require('./SQL')
 
 test('SQL helper - build complex query with append', (t) => {
   const name = 'Team 5'
@@ -8,11 +8,10 @@ test('SQL helper - build complex query with append', (t) => {
   const teamId = 7
   const organizationId = 'WONKA'
 
-  const sql = SQL`UPDATE teams SET name = ${name}, description = ${description} `
-  sql.append(SQL`WHERE id = ${teamId} AND org_id = ${organizationId}`)
+  const sql = PG`UPDATE teams SET name = ${name}, description = ${description} `
+  sql.append(PG`WHERE id = ${teamId} AND org_id = ${organizationId}`)
 
   t.equal(sql.text, 'UPDATE teams SET name = $1, description = $2 WHERE id = $3 AND org_id = $4')
-  t.equal(sql.sql, 'UPDATE teams SET name = ?, description = ? WHERE id = ? AND org_id = ?')
   t.deepEqual(sql.values, [name, description, teamId, organizationId])
   t.end()
 })
@@ -23,13 +22,12 @@ test('SQL helper - multiline', (t) => {
   const teamId = 7
   const organizationId = 'WONKA'
 
-  const sql = SQL`
+  const sql = PG`
     UPDATE teams SET name = ${name}, description = ${description}
     WHERE id = ${teamId} AND org_id = ${organizationId}
   `
 
   t.equal(sql.text, 'UPDATE teams SET name = $1, description = $2\nWHERE id = $3 AND org_id = $4')
-  t.equal(sql.sql, 'UPDATE teams SET name = ?, description = ?\nWHERE id = ? AND org_id = ?')
   t.deepEqual(sql.values, [name, description, teamId, organizationId])
   t.end()
 })
@@ -40,17 +38,16 @@ test('SQL helper - build complex query with glue', (t) => {
   const teamId = 7
   const organizationId = 'WONKA'
 
-  const sql = SQL` UPDATE teams SET `
+  const sql = PG` UPDATE teams SET `
 
   const updates = []
-  updates.push(SQL`name = ${name}`)
-  updates.push(SQL`description = ${description}`)
+  updates.push(PG`name = ${name}`)
+  updates.push(PG`description = ${description}`)
 
   sql.append(sql.glue(updates, ' , '))
-  sql.append(SQL`WHERE id = ${teamId} AND org_id = ${organizationId}`)
+  sql.append(PG`WHERE id = ${teamId} AND org_id = ${organizationId}`)
 
   t.equal(sql.text, 'UPDATE teams SET name = $1 , description = $2 WHERE id = $3 AND org_id = $4')
-  t.equal(sql.sql, 'UPDATE teams SET name = ? , description = ? WHERE id = ? AND org_id = ?')
   t.deepEqual(sql.values, [name, description, teamId, organizationId])
   t.end()
 })
@@ -65,19 +62,18 @@ test('SQL helper - build complex query with append and glue', (t) => {
   const v6 = 'v6'
   const v7 = 'v7'
 
-  const sql = SQL`TEST QUERY glue pieces FROM `
-  updates.push(SQL`v1 = ${v1}`)
-  updates.push(SQL`v2 = ${v2}`)
-  updates.push(SQL`v3 = ${v3}`)
-  updates.push(SQL`v4 = ${v4}`)
-  updates.push(SQL`v5 = ${v5}`)
+  const sql = PG`TEST QUERY glue pieces FROM `
+  updates.push(PG`v1 = ${v1}`)
+  updates.push(PG`v2 = ${v2}`)
+  updates.push(PG`v3 = ${v3}`)
+  updates.push(PG`v4 = ${v4}`)
+  updates.push(PG`v5 = ${v5}`)
 
   sql.append(sql.glue(updates, ' , '))
-  sql.append(SQL`WHERE v6 = ${v6} `)
-  sql.append(SQL`AND v7 = ${v7}`)
+  sql.append(PG`WHERE v6 = ${v6} `)
+  sql.append(PG`AND v7 = ${v7}`)
 
   t.equal(sql.text, 'TEST QUERY glue pieces FROM v1 = $1 , v2 = $2 , v3 = $3 , v4 = $4 , v5 = $5 WHERE v6 = $6 AND v7 = $7')
-  t.equal(sql.sql, 'TEST QUERY glue pieces FROM v1 = ? , v2 = ? , v3 = ? , v4 = ? , v5 = ? WHERE v6 = ? AND v7 = ?')
   t.deepEqual(sql.values, [v1, v2, v3, v4, v5, v6, v7])
   t.end()
 })
@@ -91,17 +87,16 @@ test('SQL helper - build complex query with append', (t) => {
   const v6 = 'v6'
   const v7 = 'v7'
 
-  const sql = SQL`TEST QUERY glue pieces FROM `
-  sql.append(SQL`v1 = ${v1}, `)
-  sql.append(SQL`v2 = ${v2}, `)
-  sql.append(SQL`v3 = ${v3}, `)
-  sql.append(SQL`v4 = ${v4}, `)
-  sql.append(SQL`v5 = ${v5} `)
-  sql.append(SQL`WHERE v6 = ${v6} `)
-  sql.append(SQL`AND v7 = ${v7}`)
+  const sql = PG`TEST QUERY glue pieces FROM `
+  sql.append(PG`v1 = ${v1}, `)
+  sql.append(PG`v2 = ${v2}, `)
+  sql.append(PG`v3 = ${v3}, `)
+  sql.append(PG`v4 = ${v4}, `)
+  sql.append(PG`v5 = ${v5} `)
+  sql.append(PG`WHERE v6 = ${v6} `)
+  sql.append(PG`AND v7 = ${v7}`)
 
   t.equal(sql.text, 'TEST QUERY glue pieces FROM v1 = $1, v2 = $2, v3 = $3, v4 = $4, v5 = $5 WHERE v6 = $6 AND v7 = $7')
-  t.equal(sql.sql, 'TEST QUERY glue pieces FROM v1 = ?, v2 = ?, v3 = ?, v4 = ?, v5 = ? WHERE v6 = ? AND v7 = ?')
   t.deepEqual(sql.values, [v1, v2, v3, v4, v5, v6, v7])
   t.end()
 })
@@ -115,16 +110,16 @@ test('SQL helper - build complex query with append passing simple strings and te
   const v6 = 'v6'
   const v7 = 'v7'
 
-  const sql = SQL`TEST QUERY glue pieces FROM `
-  sql.append(SQL`v1 = ${v1}, `)
-  sql.append(SQL`v2 = ${v2}, `)
-  sql.append(SQL`v3 = ${v3}, `)
-  sql.append(SQL`v4 = ${v4}, `)
-  sql.append(SQL`v5 = ${v5}, `)
-  sql.append(SQL`v6 = v6 `)
-  sql.append(SQL`WHERE v6 = ${v6} `)
-  sql.append(SQL`AND v7 = ${v7} `)
-  sql.append(SQL`AND v8 = v8`)
+  const sql = PG`TEST QUERY glue pieces FROM `
+  sql.append(PG`v1 = ${v1}, `)
+  sql.append(PG`v2 = ${v2}, `)
+  sql.append(PG`v3 = ${v3}, `)
+  sql.append(PG`v4 = ${v4}, `)
+  sql.append(PG`v5 = ${v5}, `)
+  sql.append(PG`v6 = v6 `)
+  sql.append(PG`WHERE v6 = ${v6} `)
+  sql.append(PG`AND v7 = ${v7} `)
+  sql.append(PG`AND v8 = v8`)
 
   t.equal(sql.text, 'TEST QUERY glue pieces FROM v1 = $1, v2 = $2, v3 = $3, v4 = $4, v5 = $5, v6 = v6 WHERE v6 = $6 AND v7 = $7 AND v8 = v8')
   t.deepEqual(sql.values, [v1, v2, v3, v4, v5, v6, v7])
@@ -132,12 +127,12 @@ test('SQL helper - build complex query with append passing simple strings and te
 })
 
 test('SQL helper - will throw an error if append is called without using SQL', (t) => {
-  const sql = SQL`TEST QUERY glue pieces FROM `
+  const sql = PG`TEST QUERY glue pieces FROM `
   try {
     sql.append(`v1 = v1`)
-    t.fail('showld throw an error when passing strings not prefixed with SQL')
+    t.fail('should throw an error when passing strings not prefixed with PG')
   } catch (e) {
-    t.equal(e.message, '"append" accepts only template string prefixed with SQL (SQL`...`)')
+    t.equal(e.message, '"append" accepts only template string prefixed with PG/MYSQL/ORACLE (PG`...`)')
   }
   t.end()
 })
@@ -145,11 +140,11 @@ test('SQL helper - will throw an error if append is called without using SQL', (
 test('SQL helper - build string using append with and without unsafe flag', (t) => {
   const v2 = 'v2'
   const longName = 'whateverThisIs'
-  const sql = SQL`TEST QUERY glue pieces FROM test WHERE test1 == test2`
-  sql.append(SQL` AND v1 = v1,`)
-  sql.append(SQL` AND v2 = ${v2}, `)
-  sql.append(SQL` AND v3 = ${longName}`, { unsafe: true })
-  sql.append(SQL` AND v4 = v4`, { unsafe: true })
+  const sql = PG`TEST QUERY glue pieces FROM test WHERE test1 == test2`
+  sql.append(PG` AND v1 = v1,`)
+  sql.append(PG` AND v2 = ${v2}, `)
+  sql.append(PG` AND v3 = ${longName}`, { unsafe: true })
+  sql.append(PG` AND v4 = v4`, { unsafe: true })
 
   t.equal(sql.text, 'TEST QUERY glue pieces FROM test WHERE test1 == test2 AND v1 = v1, AND v2 = $1,  AND v3 = whateverThisIs AND v4 = v4')
   t.equal(sql.values.length, 1)
@@ -161,13 +156,13 @@ test('SQL helper - build string using append and only unsafe', (t) => {
   const v2 = 'v2'
   const longName = 'whateverThisIs'
 
-  const sql = SQL`TEST QUERY glue pieces FROM test WHERE test1 == test2`
+  const sql = PG`TEST QUERY glue pieces FROM test WHERE test1 == test2`
   t.equal(sql.text, 'TEST QUERY glue pieces FROM test WHERE test1 == test2')
 
-  sql.append(SQL` AND v1 = v1,`, { unsafe: true })
+  sql.append(PG` AND v1 = v1,`, { unsafe: true })
   t.equal(sql.text, 'TEST QUERY glue pieces FROM test WHERE test1 == test2 AND v1 = v1,')
 
-  sql.append(SQL` AND v2 = ${v2} AND v3 = ${longName} AND v4 = 'v4'`, { unsafe: true })
+  sql.append(PG` AND v2 = ${v2} AND v3 = ${longName} AND v4 = 'v4'`, { unsafe: true })
   t.equal(sql.text, 'TEST QUERY glue pieces FROM test WHERE test1 == test2 AND v1 = v1, AND v2 = v2 AND v3 = whateverThisIs AND v4 = \'v4\'')
 
   t.end()

--- a/SQL.js
+++ b/SQL.js
@@ -1,7 +1,8 @@
 class SqlStatement {
-  constructor (strings, values) {
+  constructor (strings, values, type) {
     this.strings = strings
     this.values = values
+    this.type = type
   }
 
   glue (pieces, separator) {
@@ -34,13 +35,15 @@ class SqlStatement {
     )
   }
 
-  generateString (type) {
+  generateString () {
     let text = this.strings[0]
 
     for (var i = 1; i < this.strings.length; i++) {
       let delimiter = '?'
-      if (type === 'pg') {
+      if (this.type === 'pg') {
         delimiter = '$' + i
+      } else if (this.type === 'oracle') {
+        delimiter = ':' + i
       }
 
       text += delimiter + this.strings[i]
@@ -50,11 +53,7 @@ class SqlStatement {
   }
 
   get text () {
-    return this.generateString('pg')
-  }
-
-  get sql () {
-    return this.generateString('mysql')
+    return this.generateString()
   }
 
   append (statement, options) {
@@ -63,7 +62,7 @@ class SqlStatement {
     }
 
     if (!(statement instanceof SqlStatement)) {
-      throw new Error('"append" accepts only template string prefixed with SQL (SQL`...`)')
+      throw new Error('"append" accepts only template string prefixed with PG/MYSQL/ORACLE (PG`...`)')
     }
 
     if (options && options.unsafe === true) {
@@ -95,8 +94,16 @@ class SqlStatement {
   }
 }
 
-function SQL (strings, ...values) {
-  return new SqlStatement(strings, values)
+function PG (strings, ...values) {
+  return new SqlStatement(strings, values, 'pg')
 }
 
-module.exports = SQL
+function MYSQL (strings, ...values) {
+  return new SqlStatement(strings, values, 'mysql')
+}
+
+function ORACLE (strings, ...values) {
+  return new SqlStatement(strings, values, 'oracle')
+}
+
+module.exports = { PG, MYSQL, ORACLE }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "pretest:security": "napa sqlmapproject/sqlmap && node ./sqlmap/db-init.js",
     "coverage": "tap *.test.js --coverage",
     "lint": "standard",
-    "benchmark": "node benchmark/index.js"
+    "benchmark": "node benchmark/index.js",
+    "postgres": "docker run --rm -p 5432:5432 --name fastify-postgres postgres:11-alpine"
   },
   "repository": {
     "type": "git",

--- a/sqlmap/users.js
+++ b/sqlmap/users.js
@@ -1,5 +1,5 @@
 const { Client } = require('pg')
-const SQL = require('../SQL')
+const { PG } = require('../SQL')
 const config = require('./config')
 
 const client = new Client(config)
@@ -12,7 +12,7 @@ exports.register = function (server, options, next) {
     handler: function (request, reply) {
       const { limit = 10, page = 1 } = request.query
 
-      client.query(SQL`SELECT * FROM users LIMIT ${limit} OFFSET ${limit * (page - 1)}`, (err, users) => {
+      client.query(PG`SELECT * FROM users LIMIT ${limit} OFFSET ${limit * (page - 1)}`, (err, users) => {
         if (err) {
           return reply(err)
         }
@@ -28,7 +28,7 @@ exports.register = function (server, options, next) {
     handler: function (request, reply) {
       const { username, password, email } = request.payload
 
-      client.query(SQL`INSERT INTO users (username, email, password) VALUES (${username},${email},${password})`, (err, user) => {
+      client.query(PG`INSERT INTO users (username, email, password) VALUES (${username},${email},${password})`, (err, user) => {
         if (err) {
           return reply(err)
         }


### PR DESCRIPTION
This PR introduces 2 changes:

- `semver-minor` add ORACLE support
- `semver-major` split generators into different tags such as `PG`, `MYSQL`, `ORACLE`

Tests are also refactored into their own files for each tag