### PR TITLE
Fix #13

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,20 @@ sql.append(sql.glue(updates, ' , '))
 sql.append(SQL`WHERE id = ${userId}`)
 ```
 
+or also
+
+```js
+const ids = [1, 2, 3]
+const value = 'test'
+const sql = SQL` UPDATE users SET property = ${value}`
+
+const idsSqls = ids.map(id => SQL`${id}`)
+
+sql.append(SQL`WHERE id IN (`)
+sql.append(sql.glue(idsSqls, ' , '))
+sql.append(SQL`)`)
+```
+
 ## How it works?
 The SQL template string tag parses query and returns an objects that's understandable by [pg](https://www.npmjs.com/package/pg) library:
 ```js

--- a/SQL.js
+++ b/SQL.js
@@ -14,11 +14,15 @@ class SqlStatement {
       result.values = result.values.concat(pieces[i].values)
     }
 
+    if (result.strings.length === 0 && result.values.length > 0) {
+      result.strings = (new Array(result.values.length)).fill('')
+    }
+
     let strings = []
     for (let i = 0; i < result.strings.length; i++) {
       let value = result.strings[i]
 
-      if (i === 0 || value.trim() === '') {
+      if (i === 0) {
         strings.push(value)
         continue
       }

--- a/SQL.test.js
+++ b/SQL.test.js
@@ -55,6 +55,21 @@ test('SQL helper - build complex query with glue', (t) => {
   t.end()
 })
 
+test('SQL helper - build complex query with glue - regression #13', (t) => {
+  const name = 'Team 5'
+  const ids = [1, 2, 3].map(id => SQL`${id}`)
+
+  const sql = SQL`UPDATE teams SET name = ${name} `
+  sql.append(SQL`WHERE id IN (`)
+  sql.append(sql.glue(ids, ' , '))
+  sql.append(SQL`)`)
+
+  t.equal(sql.text, 'UPDATE teams SET name = $1 WHERE id IN ($2 , $3 , $4 )')
+  t.equal(sql.sql, 'UPDATE teams SET name = ? WHERE id IN (? , ? , ? )')
+  t.deepEqual(sql.values, [name, 1, 2, 3])
+  t.end()
+})
+
 test('SQL helper - build complex query with append and glue', (t) => {
   const updates = []
   const v1 = 'v1'


### PR DESCRIPTION
This PR make sure that if there are only values passed into `glue` SQL statements, they will be translated correctly into `SqlStament` `strings` and `values`.

It fixes #13 