### PR TITLE
keep significant whitespaces on multiline queries

### DIFF
--- a/SQL.js
+++ b/SQL.js
@@ -52,7 +52,9 @@ class SqlStatement {
       text += delimiter + this.strings[i]
     }
 
-    return text.replace(/^\s+|\s+$/mg, '')
+    return text
+      .replace(/\s+$/mg, ' ')
+      .replace(/^\s+|\s+$/mg, '')
   }
 
   get text () {

--- a/SQL.test.js
+++ b/SQL.test.js
@@ -36,6 +36,25 @@ test('SQL helper - multiline', (t) => {
   t.end()
 })
 
+test('SQL helper - multiline with emtpy lines', (t) => {
+  const name = 'Team 5'
+  const description = 'description'
+  const teamId = 7
+  const organizationId = 'WONKA'
+
+  const sql = SQL`
+    UPDATE teams SET name = ${name}, description = ${description}
+    WHERE id = ${teamId} AND org_id = ${organizationId}
+
+    RETURNING id
+  `
+
+  t.equal(sql.text, 'UPDATE teams SET name = $1, description = $2\nWHERE id = $3 AND org_id = $4\nRETURNING id')
+  t.equal(sql.sql, 'UPDATE teams SET name = ?, description = ?\nWHERE id = ? AND org_id = ?\nRETURNING id')
+  t.deepEqual(sql.values, [name, description, teamId, organizationId])
+  t.end()
+})
+
 test('SQL helper - build complex query with glue', (t) => {
   const name = 'Team 5'
   const description = 'description'


### PR DESCRIPTION
Before, empty lines were squashed when using multi-line strings, resulting in
erroneous syntax caused by missing spaces between lines.

Example:

The following statement

```sql
UPDATE users SET firstname = 'Max'
WHERE id = 15

RETURNING id
```

was converted to

```sql
UPDATE users SET firstname = 'Max'
WHERE id = 15RETURNING id
```

which would result in an sql error with invalid syntax.

This change would convert above sample to

```sql
UPDATE users SET firstname = 'Max'
WHERE id = 15
RETURNING id
```

while ensuring emtpy lines to still be squashed.