### PR TITLE
Add debug SQL attribute and bump dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,10 +110,13 @@ sql.sql // INSERT INTO users (username, email, password) VALUES (? , ? , ?) - fo
 sql.values // ['user, 'user@email.com', 'Password1']
 ```
 
-To help with debugging, you can also view an approximate representation of the SQL query with values filled in. It may differ from the actual SQL executed by your database, but serves as a handy reference when debugging. The debug output *should not* be executed as it is not guaranteed safe.
+To help with debugging, you can view an approximate representation of the SQL query with values filled in. It may differ from the actual SQL executed by your database, but serves as a handy reference when debugging. The debug output *should not* be executed as it is not guaranteed safe. You can may also inspect the `SQL` object via `console.log`.
 
 ```js
 sql.debug // INSERT INTO users (username, email, password) VALUES ('user','user@email.com','Password1')
+
+console.log(sql) // SQL << INSERT INTO users (username, email, password) VALUES ('user','user@email.com','Password1') >> 
+
 ```
 
 ## Testing, linting, & coverage

--- a/README.md
+++ b/README.md
@@ -110,6 +110,12 @@ sql.sql // INSERT INTO users (username, email, password) VALUES (? , ? , ?) - fo
 sql.values // ['user, 'user@email.com', 'Password1']
 ```
 
+To help with debugging, you can also view an approximate representation of the SQL query with values filled in. It may differ from the actual SQL executed by your database, but serves as a handy reference when debugging. The debug output *should not* be executed as it is not guaranteed safe.
+
+```js
+sql.debug // INSERT INTO users (username, email, password) VALUES ('user','user@email.com','Password1')
+```
+
 ## Testing, linting, & coverage
 This module can be tested and reported on in a variety of ways...
 ```sh

--- a/SQL.js
+++ b/SQL.js
@@ -1,4 +1,5 @@
 'use strict'
+const inspect = Symbol.for('nodejs.util.inspect.custom');
 
 class SqlStatement {
   constructor (strings, values) {
@@ -69,6 +70,10 @@ class SqlStatement {
     return text
       .replace(/\s+$/mg, ' ')
       .replace(/^\s+|\s+$/mg, '')
+  }
+
+  [inspect]() {
+    return `SQL << ${this.debug} >>`
   }
 
   get text () {

--- a/SQL.js
+++ b/SQL.js
@@ -57,6 +57,20 @@ class SqlStatement {
       .replace(/^\s+|\s+$/mg, '')
   }
 
+  get debug () {
+    let text = this.strings[0]
+    let data
+    for (var i = 1; i < this.strings.length; i++) {
+      data = this.values[i - 1]
+      typeof data === 'string' ? text += "'" + data + "'" : text += data
+      text += this.strings[i]
+    }
+
+    return text
+      .replace(/\s+$/mg, ' ')
+      .replace(/^\s+|\s+$/mg, '')
+  }
+
   get text () {
     return this.generateString('pg')
   }

--- a/SQL.test.js
+++ b/SQL.test.js
@@ -15,6 +15,7 @@ test('SQL helper - build complex query with append', (t) => {
 
   t.equal(sql.text, 'UPDATE teams SET name = $1, description = $2 WHERE id = $3 AND org_id = $4')
   t.equal(sql.sql, 'UPDATE teams SET name = ?, description = ? WHERE id = ? AND org_id = ?')
+  t.equal(sql.debug, `UPDATE teams SET name = '${name}', description = '${description}' WHERE id = ${teamId} AND org_id = '${organizationId}'`)
   t.deepEqual(sql.values, [name, description, teamId, organizationId])
   t.end()
 })
@@ -32,7 +33,9 @@ test('SQL helper - multiline', (t) => {
 
   t.equal(sql.text, 'UPDATE teams SET name = $1, description = $2\nWHERE id = $3 AND org_id = $4')
   t.equal(sql.sql, 'UPDATE teams SET name = ?, description = ?\nWHERE id = ? AND org_id = ?')
+  t.equal(sql.debug, `UPDATE teams SET name = '${name}', description = '${description}'\nWHERE id = ${teamId} AND org_id = '${organizationId}'`)
   t.deepEqual(sql.values, [name, description, teamId, organizationId])
+
   t.end()
 })
 
@@ -51,6 +54,7 @@ test('SQL helper - multiline with emtpy lines', (t) => {
 
   t.equal(sql.text, 'UPDATE teams SET name = $1, description = $2\nWHERE id = $3 AND org_id = $4\nRETURNING id')
   t.equal(sql.sql, 'UPDATE teams SET name = ?, description = ?\nWHERE id = ? AND org_id = ?\nRETURNING id')
+  t.equal(sql.debug, `UPDATE teams SET name = '${name}', description = '${description}'\nWHERE id = ${teamId} AND org_id = '${organizationId}'\nRETURNING id`)
   t.deepEqual(sql.values, [name, description, teamId, organizationId])
   t.end()
 })
@@ -72,6 +76,7 @@ test('SQL helper - build complex query with glue', (t) => {
 
   t.equal(sql.text, 'UPDATE teams SET name = $1 , description = $2 WHERE id = $3 AND org_id = $4')
   t.equal(sql.sql, 'UPDATE teams SET name = ? , description = ? WHERE id = ? AND org_id = ?')
+  t.equal(sql.debug, `UPDATE teams SET name = '${name}' , description = '${description}' WHERE id = ${teamId} AND org_id = '${organizationId}'`)
   t.deepEqual(sql.values, [name, description, teamId, organizationId])
   t.end()
 })
@@ -87,6 +92,7 @@ test('SQL helper - build complex query with glue - regression #13', (t) => {
 
   t.equal(sql.text, 'UPDATE teams SET name = $1 WHERE id IN ($2 , $3 , $4 )')
   t.equal(sql.sql, 'UPDATE teams SET name = ? WHERE id IN (? , ? , ? )')
+  t.equal(sql.debug, `UPDATE teams SET name = '${name}' WHERE id IN (1 , 2 , 3 )`)
   t.deepEqual(sql.values, [name, 1, 2, 3])
   t.end()
 })
@@ -114,6 +120,7 @@ test('SQL helper - build complex query with append and glue', (t) => {
 
   t.equal(sql.text, 'TEST QUERY glue pieces FROM v1 = $1 , v2 = $2 , v3 = $3 , v4 = $4 , v5 = $5 WHERE v6 = $6 AND v7 = $7')
   t.equal(sql.sql, 'TEST QUERY glue pieces FROM v1 = ? , v2 = ? , v3 = ? , v4 = ? , v5 = ? WHERE v6 = ? AND v7 = ?')
+  t.equal(sql.debug, `TEST QUERY glue pieces FROM v1 = 'v1' , v2 = 'v2' , v3 = 'v3' , v4 = 'v4' , v5 = 'v5' WHERE v6 = 'v6' AND v7 = 'v7'`)
   t.deepEqual(sql.values, [v1, v2, v3, v4, v5, v6, v7])
   t.end()
 })
@@ -138,6 +145,7 @@ test('SQL helper - build complex query with append', (t) => {
 
   t.equal(sql.text, 'TEST QUERY glue pieces FROM v1 = $1, v2 = $2, v3 = $3, v4 = $4, v5 = $5 WHERE v6 = $6 AND v7 = $7')
   t.equal(sql.sql, 'TEST QUERY glue pieces FROM v1 = ?, v2 = ?, v3 = ?, v4 = ?, v5 = ? WHERE v6 = ? AND v7 = ?')
+  t.equal(sql.debug, `TEST QUERY glue pieces FROM v1 = 'v1', v2 = 'v2', v3 = 'v3', v4 = 'v4', v5 = 'v5' WHERE v6 = 'v6' AND v7 = 'v7'`)
   t.deepEqual(sql.values, [v1, v2, v3, v4, v5, v6, v7])
   t.end()
 })
@@ -163,6 +171,7 @@ test('SQL helper - build complex query with append passing simple strings and te
   sql.append(SQL`AND v8 = v8`)
 
   t.equal(sql.text, 'TEST QUERY glue pieces FROM v1 = $1, v2 = $2, v3 = $3, v4 = $4, v5 = $5, v6 = v6 WHERE v6 = $6 AND v7 = $7 AND v8 = v8')
+  t.equal(sql.debug, `TEST QUERY glue pieces FROM v1 = 'v1', v2 = 'v2', v3 = 'v3', v4 = 'v4', v5 = 'v5', v6 = v6 WHERE v6 = 'v6' AND v7 = 'v7' AND v8 = v8`)
   t.deepEqual(sql.values, [v1, v2, v3, v4, v5, v6, v7])
   t.end()
 })
@@ -188,6 +197,7 @@ test('SQL helper - build string using append with and without unsafe flag', (t) 
   sql.append(SQL` AND v4 = v4`, { unsafe: true })
 
   t.equal(sql.text, 'TEST QUERY glue pieces FROM test WHERE test1 == test2 AND v1 = v1, AND v2 = $1,  AND v3 = whateverThisIs AND v4 = v4')
+  t.equal(sql.debug, `TEST QUERY glue pieces FROM test WHERE test1 == test2 AND v1 = v1, AND v2 = 'v2',  AND v3 = whateverThisIs AND v4 = v4`)
   t.equal(sql.values.length, 1)
   t.true(sql.values.includes(v2))
   t.end()
@@ -205,6 +215,7 @@ test('SQL helper - build string using append and only unsafe', (t) => {
 
   sql.append(SQL` AND v2 = ${v2} AND v3 = ${longName} AND v4 = 'v4'`, { unsafe: true })
   t.equal(sql.text, 'TEST QUERY glue pieces FROM test WHERE test1 == test2 AND v1 = v1, AND v2 = v2 AND v3 = whateverThisIs AND v4 = \'v4\'')
+  t.equal(sql.debug, `TEST QUERY glue pieces FROM test WHERE test1 == test2 AND v1 = v1, AND v2 = v2 AND v3 = whateverThisIs AND v4 = 'v4'`)
 
   t.end()
 })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nearform/sql",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "SQL injection protection module",
   "main": "./SQL.js",
   "scripts": {
@@ -22,15 +22,15 @@
   },
   "homepage": "https://github.com/nearform/sql#readme",
   "devDependencies": {
-    "async": "^2.6.1",
+    "async": "^2.6.2",
     "benchmark": "^2.1.4",
-    "hapi": "^16.6.2",
-    "jsonfile": "^4.0.0",
+    "hapi": "^18.1.0",
+    "jsonfile": "^5.0.0",
     "napa": "^3.0.0",
-    "pg": "^7.4.3",
+    "pg": "^7.10.0",
     "sql-template-strings": "^2.2.2",
-    "standard": "^11.0.0",
-    "tap": "^12.0.0"
+    "standard": "^12.0.1",
+    "tap": "^12.6.2"
   },
   "standard": {
     "ignore": [


### PR DESCRIPTION
This PR allows someone to view a crude version of the complete SQL query for debugging. The query is not intended to be 100% correct or executable, but rather is supposed to be a handy reference when developing.  

I would appreciate your consideration of this feature. I have been using this module for a number of weeks now and the ability to view a complete SQL statement rather than attempting to piece it together in the terminal would make life easier. 

I have also bumped the version numbers of the dev dependencies. 

Feedback is appreciated and welcomed.