### PR TITLE
Fix #17

### DIFF
--- a/SQL.js
+++ b/SQL.js
@@ -10,30 +10,29 @@ class SqlStatement {
   glue (pieces, separator) {
     const result = { strings: [], values: [] }
 
+    let carryover
     for (let i = 0; i < pieces.length; i++) {
-      let strings = pieces[i].strings.filter(s => !!s.trim())
+      let strings = Array.from(pieces[i].strings)
+      if (typeof carryover === 'string') {
+        strings[0] = carryover + separator + strings[0]
+        carryover = null
+      }
 
+      if (strings.length > pieces[i].values.length) {
+        carryover = strings.splice(-1)[0]
+      }
       result.strings = result.strings.concat(strings)
       result.values = result.values.concat(pieces[i].values)
     }
-
-    if (result.strings.length === 0 && result.values.length > 0) {
-      result.strings = (new Array(result.values.length)).fill('')
+    if (typeof carryover === 'string') {
+      result.strings.push(carryover)
     }
 
-    let strings = []
-    for (let i = 0; i < result.strings.length; i++) {
-      let value = result.strings[i]
-
-      if (i === 0) {
-        strings.push(value)
-        continue
-      }
-
-      strings.push(separator + value)
+    if (result.strings.length === result.values.length) {
+      result.strings.push('')
     }
 
-    result.strings = strings.concat([' '])
+    result.strings[result.strings.length - 1] += ' '
 
     return new SqlStatement(
       result.strings,

--- a/SQL.test.js
+++ b/SQL.test.js
@@ -97,6 +97,19 @@ test('SQL helper - build complex query with glue - regression #13', (t) => {
   t.end()
 })
 
+test('SQL helper - build complex query with glue - regression #17', (t) => {
+  const ids = [1, 2, 3].map(id => SQL`(${id})`)
+
+  const sql = SQL`INSERT INTO users (id) VALUES `
+  sql.append(sql.glue(ids, ' , '))
+
+  t.equal(sql.text, 'INSERT INTO users (id) VALUES ($1) , ($2) , ($3)')
+  t.equal(sql.sql, 'INSERT INTO users (id) VALUES (?) , (?) , (?)')
+  t.equal(sql.debug, `INSERT INTO users (id) VALUES (1) , (2) , (3)`)
+  t.deepEqual(sql.values, [1, 2, 3])
+  t.end()
+})
+
 test('SQL helper - build complex query with append and glue', (t) => {
   const updates = []
   const v1 = 'v1'


### PR DESCRIPTION
Fixes https://github.com/nearform/sql/issues/17 (Algo was choking on bracket wrapping [`(1)`, `(2)`, `(3)`] )
Adds test coverage
Benchmarks don't seem to use glue

In general I tried to follow existing conventions, but:
If you prefer more declarative style I can revisit the `carryover` var
If you prefer I can use array member methods instead of directly accessing and writing to elements

Suggestion to upgrade glue into static util will be addressed in separate MR