### PR TITLE
Fix unit tests and sqlmap scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,23 +27,26 @@ build-lint-test: &build-lint-test
       command: node -v
 
   # https://discuss.circleci.com/t/sudo-command-not-found/14208/4
-  - run: apt-get update
-  - run: apt-get install -y sudo
+  - run:
+      name: Install sudo
+      command: apt-get update && apt-get install -y sudo
 
   - run:
-      name: install dockerize
-      command: wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && sudo tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+      name: Install dockerize
+      command: >
+        wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz &&
+        sudo tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz &&
+        rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
       environment:
         DOCKERIZE_VERSION: v0.6.1
+
   - run:
-      name: Wait for db
+      name: Wait for PostgreSQL to be ready
       command: dockerize -wait tcp://127.0.0.1:5432 -timeout 1m
-  # Download and cache dependencies
-  - run: npm install
-  - persist_to_workspace:
-      root: ~/
-      paths:
-        - workspace
+
+  - run:
+      name: Install npm dependencies
+      command: npm install
 
   - run:
       name: Lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,8 @@
 # Check https://circleci.com/docs/2.0/language-javascript/ for more details
 #
 
+version: 2
+
 defaults:
   - &working_directory ~/workspace
   - &postgres
@@ -43,7 +45,7 @@ build-lint-test: &build-lint-test
       paths:
         - workspace
 
-  - run: 
+  - run:
       name: Lint
       command: npm run lint
 
@@ -51,11 +53,11 @@ build-lint-test: &build-lint-test
       name: Test
       command: npm run test
 
-  - run: 
+  - run:
       name: Coverage
       command: npm run coverage
 
-  - run: 
+  - run:
       name: Test Security
       command: npm run test:security
 

--- a/SQL.test-d.ts
+++ b/SQL.test-d.ts
@@ -1,5 +1,5 @@
-import * as SQL from './sql'
-import { glue, SqlStatement } from './sql'
+import * as SQL from '.'
+import { glue, SqlStatement } from '.'
 import { expectType, expectError } from 'tsd'
 
 expectType<SqlStatement>(SQL`SELECT 1`)

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "homepage": "https://github.com/nearform/sql#readme",
   "devDependencies": {
+    "@hapi/hapi": "^18.4.0",
     "async": "^2.6.2",
     "benchmark": "^2.1.4",
     "hapi": "^18.1.0",

--- a/sqlmap/injection-endpoints.json
+++ b/sqlmap/injection-endpoints.json
@@ -13,7 +13,7 @@
     {
       "url": "http://localhost:8080/users",
       "method": "POST",
-      "headers": "Content-Type: application/json",
+      "headers": "Content-Type:application/json",
       "params": "username,password,email",
       "data": "{\"username\":\"user\",\"password\":\"12345\",\"email\":\"user@email.com\"}"
     }

--- a/sqlmap/server.js
+++ b/sqlmap/server.js
@@ -4,10 +4,11 @@ const users = require('./users')
 
 server.register([users])
   .then(() => server.start())
-  .then(
-    () => logMessage('Server started on: http://localhost:8080'),
-    (err) => logMessage(`Failed to start server: ${err.message}`)
-  )
+  .then(() => logMessage('Server started on: http://localhost:8080'))
+  .catch((err) => {
+    logMessage(`Failed to start server: ${err.message}`)
+    process.exit(1)
+  })
 
 // if forked as child, send output message via ipc to parent
 // otherwise output to console

--- a/sqlmap/server.js
+++ b/sqlmap/server.js
@@ -1,23 +1,13 @@
-const Hapi = require('hapi')
-const server = new Hapi.Server()
+const Hapi = require('@hapi/hapi')
+const server = Hapi.Server({ port: 8080 })
+const users = require('./users')
 
-server.connection({
-  port: 8080,
-  host: 'localhost'
-})
-
-server.register([
-  {
-    register: require('./users')
-  }
-])
-
-server.start((err) => {
-  if (err) {
-    return logMessage(`Failed to start server: ${err.message}`)
-  }
-  logMessage('Server started on: http://localhost:8080')
-})
+server.register([users])
+  .then(() => server.start())
+  .then(
+    () => logMessage('Server started on: http://localhost:8080'),
+    (err) => logMessage(`Failed to start server: ${err.message}`)
+  )
 
 // if forked as child, send output message via ipc to parent
 // otherwise output to console

--- a/sqlmap/sqlmap.js
+++ b/sqlmap/sqlmap.js
@@ -99,14 +99,20 @@ hapi.on('close', (code) => {
   process.exit(1)
 })
 
+hapi.stdout.on('data', (data) => {
+  console.log(`${hapiChalk} ${data}`)
+})
+
+hapi.stderr.on('data', (data) => {
+  console.log(`${hapiChalk} ${chalk.red(data)}`)
+})
+
 async.detect(['python2', 'python'], findPython2, function (err, python) {
   if (err) {
     return console.error(chalk.red(err))
   }
 
   hapi.stdout.once('data', (data) => {
-    console.log(`${hapiChalk} ${data}`)
-
     async.everySeries(endpoints.urls, (urlDescription, done) => {
       executeMap(python, endpoints, urlDescription, (err, vulnerabilities) => {
         if (err) {
@@ -133,9 +139,5 @@ async.detect(['python2', 'python'], findPython2, function (err, python) {
         return process.exit(1)
       }
     })
-  })
-
-  hapi.stderr.on('data', (data) => {
-    console.log(`\n${hapiChalk} ${chalk.red(`stderr: ${data}`)}`)
   })
 })

--- a/sqlmap/users.js
+++ b/sqlmap/users.js
@@ -15,10 +15,9 @@ module.exports = {
           const { limit = 10, page = 1 } = request.query
 
           return client.query(SQL`SELECT * FROM users LIMIT ${limit} OFFSET ${limit * (page - 1)}`)
-            .then((users) => {
-              const response = h.response(users)
-              response.code(201)
-              return response
+            .then((result) => {
+              const users = result.rows
+              return h.response(users)
             })
         }
       })
@@ -30,10 +29,9 @@ module.exports = {
           const { username, password, email } = request.payload
 
           return client.query(SQL`INSERT INTO users (username, email, password) VALUES (${username},${email},${password})`)
-            .then((user) => {
-              const response = h.response(user)
-              response.code(201)
-              return response
+            .then((result) => {
+              if (result.command !== 'INSERT' || result.rowCount !== 1) return new Error('User was not inserted')
+              return h.response().code(201)
             })
         }
       })


### PR DESCRIPTION
resolves #27 

There were a bunch of issues with this:

* The TypeScript `tsd` tests from #26 were failing because they had the wrong file case. This has been changed to reference `'.'` to allow node to use `package.json#main` for the package entry point.
* There was some confusing use of the `hapi` v16 API even though v18 was installed. This has been updated to use `@hapi/hapi` v18 and I've changed the code accordingly for that API.
* `sqlmap` failures (invoked by the `npm run test:security` script) were being ignored. These have been changed to exit the process with a non-zero code when a failure is detected.

I've also made the following additional changes:
* adjusted the console output from the `test:security` to be slightly easier to read. It's now more obvious to see the source of a log line.
* annotated some of the `.circleci/config.yml` commands to help when reading the output, and removed workspace persistence

The goal of this PR was to get the tests running and reporting failures correctly. A followup step is to move away from CircleCI on to GitHub Actions.