### PR TITLE
fix: performance issues calling glue with large arrays

### DIFF
--- a/SQL.js
+++ b/SQL.js
@@ -24,8 +24,8 @@ class SqlStatement {
       if (strings.length > pieces[i].values.length) {
         carryover = strings.splice(-1)[0]
       }
-      result.strings = result.strings.concat(strings)
-      result.values = result.values.concat(pieces[i].values)
+      result.strings.push.apply(result.strings, strings)
+      result.values.push.apply(result.values, pieces[i].values)
     }
     if (typeof carryover === 'string') {
       result.strings.push(carryover)


### PR DESCRIPTION
resolves #37 

Replaces calls to `.concat()` with `.push()` for huge performance benefits. Locally, calling `.glue()` with an array with 100000 entries would take around 29765ms to complete, and with these changes produces the same output in 55ms.

```
glue (100,000 entries, concat) x 0.03 ops/sec ±3.26% (5 runs sampled)
glue (100,000 entries, push) x 79.24 ops/sec ±1.18% (68 runs sampled)
```