### PR TITLE
chore: safe quoteIdent

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,11 @@ const sql = SQL`
 
 ### quoteIdent(value)
 
-Does a literal interpolation of the provided value, interpreting the provided value as-is and additionally wrapping it in double quotes. It uses `unsafe` internally.
+Mimics the native PostgreSQL `quote_ident` and MySQL `quote_identifier` functions.
+
+In PostgreSQL, it wraps the provided value in double quotes `"` and escapes any double quotes existing in the provided value.
+
+In MySQL, it wraps the provided value in backticks `` ` `` and escapes any backticks existing in the provided value.
 
 It's convenient to use when schema, table or field names are dynamic and can't be hardcoded in the SQL query string.
 

--- a/SQL.test.js
+++ b/SQL.test.js
@@ -7,7 +7,7 @@ const SQL = require('./SQL')
 const unsafe = SQL.unsafe
 const quoteIdent = SQL.quoteIdent
 
-test('SQL helper - build complex query with append', t => {
+test('SQL helper - build complex query with append', async t => {
   const name = 'Team 5'
   const description = 'description'
   const teamId = 7
@@ -29,10 +29,9 @@ test('SQL helper - build complex query with append', t => {
     `UPDATE teams SET name = '${name}', description = '${description}' WHERE id = ${teamId} AND org_id = '${organizationId}'`
   )
   t.same(sql.values, [name, description, teamId, organizationId])
-  t.end()
 })
 
-test('SQL helper - multiline', t => {
+test('SQL helper - multiline', async t => {
   const name = 'Team 5'
   const description = 'description'
   const teamId = 7
@@ -56,11 +55,9 @@ test('SQL helper - multiline', t => {
     `UPDATE teams SET name = '${name}', description = '${description}'\nWHERE id = ${teamId} AND org_id = '${organizationId}'`
   )
   t.same(sql.values, [name, description, teamId, organizationId])
-
-  t.end()
 })
 
-test('SQL helper - multiline with emtpy lines', t => {
+test('SQL helper - multiline with emtpy lines', async t => {
   const name = 'Team 5'
   const description = 'description'
   const teamId = 7
@@ -86,10 +83,9 @@ test('SQL helper - multiline with emtpy lines', t => {
     `UPDATE teams SET name = '${name}', description = '${description}'\nWHERE id = ${teamId} AND org_id = '${organizationId}'\nRETURNING id`
   )
   t.same(sql.values, [name, description, teamId, organizationId])
-  t.end()
 })
 
-test('SQL helper - build complex query with glue', t => {
+test('SQL helper - build complex query with glue', async t => {
   const name = 'Team 5'
   const description = 'description'
   const teamId = 7
@@ -117,10 +113,9 @@ test('SQL helper - build complex query with glue', t => {
     `UPDATE teams SET name = '${name}' , description = '${description}' WHERE id = ${teamId} AND org_id = '${organizationId}'`
   )
   t.same(sql.values, [name, description, teamId, organizationId])
-  t.end()
 })
 
-test('SQL helper - build complex query with glue - regression #13', t => {
+test('SQL helper - build complex query with glue - regression #13', async t => {
   const name = 'Team 5'
   const ids = [1, 2, 3].map(id => SQL`${id}`)
 
@@ -136,10 +131,9 @@ test('SQL helper - build complex query with glue - regression #13', t => {
     `UPDATE teams SET name = '${name}' WHERE id IN (1 , 2 , 3 )`
   )
   t.same(sql.values, [name, 1, 2, 3])
-  t.end()
 })
 
-test('SQL helper - build complex query with glue - regression #17', t => {
+test('SQL helper - build complex query with glue - regression #17', async t => {
   const ids = [1, 2, 3].map(id => SQL`(${id})`)
 
   const sql = SQL`INSERT INTO users (id) VALUES `
@@ -149,10 +143,9 @@ test('SQL helper - build complex query with glue - regression #17', t => {
   t.equal(sql.sql, 'INSERT INTO users (id) VALUES (?) , (?) , (?)')
   t.equal(sql.debug, 'INSERT INTO users (id) VALUES (1) , (2) , (3)')
   t.same(sql.values, [1, 2, 3])
-  t.end()
 })
 
-test('SQL helper - build complex query with static glue - regression #17', t => {
+test('SQL helper - build complex query with static glue - regression #17', async t => {
   const ids = [1, 2, 3].map(id => SQL`(${id})`)
 
   const sql = SQL`INSERT INTO users (id) VALUES `
@@ -162,10 +155,9 @@ test('SQL helper - build complex query with static glue - regression #17', t => 
   t.equal(sql.sql, 'INSERT INTO users (id) VALUES (?) , (?) , (?)')
   t.equal(sql.debug, 'INSERT INTO users (id) VALUES (1) , (2) , (3)')
   t.same(sql.values, [1, 2, 3])
-  t.end()
 })
 
-test('SQL helper - build complex query with append and glue', t => {
+test('SQL helper - build complex query with append and glue', async t => {
   const updates = []
   const v1 = 'v1'
   const v2 = 'v2'
@@ -199,10 +191,9 @@ test('SQL helper - build complex query with append and glue', t => {
     "TEST QUERY glue pieces FROM v1 = 'v1' , v2 = 'v2' , v3 = 'v3' , v4 = 'v4' , v5 = 'v5' WHERE v6 = 'v6' AND v7 = 'v7'"
   )
   t.same(sql.values, [v1, v2, v3, v4, v5, v6, v7])
-  t.end()
 })
 
-test('SQL helper - build complex query with append', t => {
+test('SQL helper - build complex query with append', async t => {
   const v1 = 'v1'
   const v2 = 'v2'
   const v3 = 'v3'
@@ -233,10 +224,9 @@ test('SQL helper - build complex query with append', t => {
     "TEST QUERY glue pieces FROM v1 = 'v1', v2 = 'v2', v3 = 'v3', v4 = 'v4', v5 = 'v5' WHERE v6 = 'v6' AND v7 = 'v7'"
   )
   t.same(sql.values, [v1, v2, v3, v4, v5, v6, v7])
-  t.end()
 })
 
-test('SQL helper - build complex query with append passing simple strings and template strings', t => {
+test('SQL helper - build complex query with append passing simple strings and template strings', async t => {
   const v1 = 'v1'
   const v2 = 'v2'
   const v3 = 'v3'
@@ -265,10 +255,9 @@ test('SQL helper - build complex query with append passing simple strings and te
     "TEST QUERY glue pieces FROM v1 = 'v1', v2 = 'v2', v3 = 'v3', v4 = 'v4', v5 = 'v5', v6 = v6 WHERE v6 = 'v6' AND v7 = 'v7' AND v8 = v8"
   )
   t.same(sql.values, [v1, v2, v3, v4, v5, v6, v7])
-  t.end()
 })
 
-test('SQL helper - will throw an error if append is called without using SQL', t => {
+test('SQL helper - will throw an error if append is called without using SQL', async t => {
   const sql = SQL`TEST QUERY glue pieces FROM `
   try {
     sql.append('v1 = v1')
@@ -279,10 +268,9 @@ test('SQL helper - will throw an error if append is called without using SQL', t
       '"append" accepts only template string prefixed with SQL (SQL`...`)'
     )
   }
-  t.end()
 })
 
-test('SQL helper - build string using append with and without unsafe flag', t => {
+test('SQL helper - build string using append with and without unsafe flag', async t => {
   const v2 = 'v2'
   const longName = 'whateverThisIs'
   const sql = SQL`TEST QUERY glue pieces FROM test WHERE test1 == test2`
@@ -301,10 +289,9 @@ test('SQL helper - build string using append with and without unsafe flag', t =>
   )
   t.equal(sql.values.length, 1)
   t.ok(sql.values.includes(v2))
-  t.end()
 })
 
-test('SQL helper - build string using append and only unsafe', t => {
+test('SQL helper - build string using append and only unsafe', async t => {
   const v2 = 'v2'
   const longName = 'whateverThisIs'
 
@@ -328,11 +315,9 @@ test('SQL helper - build string using append and only unsafe', t => {
     sql.debug,
     "TEST QUERY glue pieces FROM test WHERE test1 == test2 AND v1 = v1, AND v2 = v2 AND v3 = whateverThisIs AND v4 = 'v4'"
   )
-
-  t.end()
 })
 
-test('SQL helper - handles js null values as valid `null` sql values', t => {
+test('SQL helper - handles js null values as valid `null` sql values', async t => {
   const name = null
   const id = 123
 
@@ -342,49 +327,44 @@ test('SQL helper - handles js null values as valid `null` sql values', t => {
   t.equal(sql.sql, 'UPDATE teams SET name = ? WHERE id = ?')
   t.equal(sql.debug, `UPDATE teams SET name = null WHERE id = ${id}`)
   t.same(sql.values, [name, id])
-  t.end()
 })
 
-test('SQL helper - throws when building an sql string with an `undefined` value', t => {
+test('SQL helper - throws when building an sql string with an `undefined` value', async t => {
   t.throws(() => SQL`UPDATE teams SET name = ${undefined}`)
-  t.end()
 })
 
-test('empty append', t => {
+test('empty append', async t => {
   const sql = SQL`UPDATE teams SET name = ${'team'}`.append()
 
   t.equal(sql.text, 'UPDATE teams SET name = $1')
   t.equal(sql.sql, 'UPDATE teams SET name = ?')
   t.equal(sql.debug, "UPDATE teams SET name = 'team'")
   t.same(sql.values, ['team'])
-
-  t.end()
 })
 
-test('inspect', t => {
+test('inspect', async t => {
   const sql = SQL`UPDATE teams SET name = ${'team'}`
-
   t.equal(util.inspect(sql), "SQL << UPDATE teams SET name = 'team' >>")
-  t.end()
 })
 
-test('quoteIdent', t => {
-  const table = 'teams'
-  const name = 'name'
-  const id = 123
+test('quoteIdent', async t => {
+  t.test('simple', async t => {
+    const table = 'teams'
+    const name = 'name'
+    const id = 123
 
-  const sql = SQL`UPDATE ${quoteIdent(
-    table
-  )} SET name = ${name} WHERE id = ${id}`
+    const sql = SQL`UPDATE ${quoteIdent(
+      table
+    )} SET name = ${name} WHERE id = ${id}`
 
-  t.equal(sql.text, 'UPDATE "teams" SET name = $1 WHERE id = $2')
-  t.equal(sql.sql, 'UPDATE "teams" SET name = ? WHERE id = ?')
-  t.equal(sql.debug, `UPDATE "teams" SET name = 'name' WHERE id = ${id}`)
-  t.same(sql.values, [name, id])
-  t.end()
+    t.equal(sql.text, 'UPDATE "teams" SET name = $1 WHERE id = $2')
+    t.equal(sql.sql, 'UPDATE `teams` SET name = ? WHERE id = ?')
+    t.equal(sql.debug, `UPDATE "teams" SET name = 'name' WHERE id = ${id}`)
+    t.same(sql.values, [name, id])
+  })
 })
 
-test('unsafe', t => {
+test('unsafe', async t => {
   const name = 'name'
   const id = 123
 
@@ -394,10 +374,9 @@ test('unsafe', t => {
   t.equal(sql.sql, "UPDATE teams SET name = 'name' WHERE id = ?")
   t.equal(sql.debug, `UPDATE teams SET name = 'name' WHERE id = ${id}`)
   t.same(sql.values, [id])
-  t.end()
 })
 
-test('should be able to append query that is using "{ unsafe: true }"', t => {
+test('should be able to append query that is using "{ unsafe: true }"', async t => {
   const table = 'teams'
   const id = 123
 
@@ -424,11 +403,9 @@ test('should be able to append query that is using "{ unsafe: true }"', t => {
     `SELECT * FROM teams INNER JOIN (SELECT id FROM teams WHERE id = ${id}) as t2 ON t2.id = id`
   )
   t.same(sql.values, [id])
-
-  t.end()
 })
 
-test('should be able to append query that is using "quoteIdent(...)"', t => {
+test('should be able to append query that is using "quoteIdent(...)"', async t => {
   const table = 'teams'
   const id = 123
 
@@ -444,12 +421,11 @@ test('should be able to append query that is using "quoteIdent(...)"', t => {
   )
   t.equal(
     sql.sql,
-    'SELECT * FROM "teams" INNER JOIN (SELECT id FROM "teams" WHERE id = ?) as t2 ON t2.id = id'
+    'SELECT * FROM `teams` INNER JOIN (SELECT id FROM `teams` WHERE id = ?) as t2 ON t2.id = id'
   )
   t.equal(
     sql.debug,
     `SELECT * FROM "teams" INNER JOIN (SELECT id FROM "teams" WHERE id = ${id}) as t2 ON t2.id = id`
   )
   t.same(sql.values, [id])
-  t.end()
 })

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.4'
+services:
+  db:
+    image: postgres:9-alpine
+    environment:
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_USER: postgres
+      POSTGRES_DB: sqlmap
+    ports:
+      - 5432:5432

--- a/quoteIdentifier.js
+++ b/quoteIdentifier.js
@@ -1,0 +1,11 @@
+'use strict'
+
+function quoteIdentifier (value, type) {
+  const quote = type === 'mysql' ? '`' : '"'
+
+  const quoted = value.replace(new RegExp(quote, 'g'), `${quote}${quote}`)
+
+  return `${quote}${quoted}${quote}`
+}
+
+module.exports = quoteIdentifier

--- a/quoteIdentifier.test.js
+++ b/quoteIdentifier.test.js
@@ -1,0 +1,36 @@
+'use strict'
+
+const test = require('tap').test
+const quoteIdentifier = require('./quoteIdentifier')
+
+test('quoteIdentifier', async t => {
+  t.test('pg', async t => {
+    t.test('simple', async t => {
+      t.same(quoteIdentifier('identifier', 'pg'), '"identifier"')
+    })
+
+    t.test('with quotes', async t => {
+      t.same(quoteIdentifier('"quotes"', 'pg'), '"""quotes"""')
+    })
+  })
+
+  t.test('mysql', async t => {
+    t.test('simple', async t => {
+      t.same(quoteIdentifier('identifier', 'mysql'), '`identifier`')
+    })
+
+    t.test('with quotes', async t => {
+      t.same(quoteIdentifier('`quotes`', 'mysql'), '```quotes```')
+    })
+  })
+
+  t.test('without type', async t => {
+    t.test('simple', async t => {
+      t.same(quoteIdentifier('identifier'), '"identifier"')
+    })
+
+    t.test('with quotes', async t => {
+      t.same(quoteIdentifier('"quotes"'), '"""quotes"""')
+    })
+  })
+})

--- a/sqlmap/injection-endpoints.json
+++ b/sqlmap/injection-endpoints.json
@@ -12,10 +12,15 @@
     },
     {
       "url": "http://localhost:8080/users",
-      "method": "POST",
       "headers": "Content-Type:application/json",
       "params": "username,password,email",
       "data": "{\"username\":\"user\",\"password\":\"12345\",\"email\":\"user@email.com\"}"
+    },
+    {
+      "url": "http://localhost:8080/table",
+      "headers": "Content-Type:application/json",
+      "params": "tableName,field1,field2",
+      "data": "{\"tableName\":\"some_table\",\"field1\":\"id\",\"field2\":\"username\"}"
     }
   ]
 }

--- a/sqlmap/server.js
+++ b/sqlmap/server.js
@@ -1,4 +1,5 @@
 const users = require('./users')
+const table = require('./table')
 
 const fastify = require('fastify')({
   logger: false
@@ -6,6 +7,7 @@ const fastify = require('fastify')({
 
 fastify.register(require('fastify-postgres'), require('./config'))
 fastify.register(users)
+fastify.register(table)
 
 const start = async () => {
   try {

--- a/sqlmap/sqlmap.js
+++ b/sqlmap/sqlmap.js
@@ -35,7 +35,6 @@ const executeMap = (command, config, urlDescription, done) => {
   const params = [
     './node_modules/sqlmap/sqlmap.py',
     `--url=${urlDescription.url}`,
-    `--method=${urlDescription.method}`,
     `--level=${config.level}`,
     `--risk=${config.risk}`,
     `--dbms=${config.dbms}`,
@@ -45,6 +44,10 @@ const executeMap = (command, config, urlDescription, done) => {
     '--flush-session',
     '--batch'
   ]
+
+  if (urlDescription.method) {
+    params.push(`--method=${urlDescription.method}`)
+  }
 
   if (urlDescription.headers) {
     params.push(`--headers=${urlDescription.headers}`)

--- a/sqlmap/table.js
+++ b/sqlmap/table.js
@@ -1,0 +1,17 @@
+const SQL = require('../SQL')
+const quoteIdent = SQL.quoteIdent
+
+module.exports = async function (fastify) {
+  fastify.post('/table', async request => {
+    const { tableName, field1, field2 } = request.body
+
+    await fastify.pg.query(
+      SQL`CREATE TABLE ${quoteIdent(tableName)} (
+        ${quoteIdent(field1)} SERIAL PRIMARY KEY, 
+        ${quoteIdent(field2)} VARCHAR (30)
+      )`
+    )
+
+    return fastify.pg.query(SQL`DROP TABLE ${quoteIdent(tableName)} `)
+  })
+}

--- a/sqlmap/users.js
+++ b/sqlmap/users.js
@@ -1,4 +1,5 @@
 const SQL = require('../SQL')
+const quoteIdent = SQL.quoteIdent
 
 const tableName = 'users'
 
@@ -19,7 +20,7 @@ module.exports = async function (fastify) {
     const { username, password, email } = request.body
 
     const result = await fastify.pg.query(
-      SQL`INSERT INTO ${SQL.quoteIdent(
+      SQL`INSERT INTO ${quoteIdent(
         tableName
       )} (username, email, password) VALUES (${username},${email},${password})`
     )


### PR DESCRIPTION
Closes #49 by implementing `quoteIdent` so that:

- on pg: keeps using double quotes `"` 
- on mysql: uses backticks `` ` ``

In both cases, escape the quote character if included in the provided identifier, which is what makes it safe and it's what pg and mysql quoting functions do too, see:

- pg: https://doxygen.postgresql.org/ruleutils_8c.html#a30a0e11b313ae9c277420959cd655ac2
- mysql: https://github.com/mysql/mysql-server/blob/3e90d07c3578e4da39dc1bce73559bbdf655c28c/scripts/sys_schema/functions/quote_identifier.sql

Note that this implementation is simpler because it just quotes unconditionally, whereas the pg implementation only quotes if the identifier is unsafe. This allows a simpler implementation while preserving the same level of safety.

Also includes:

- making all tests async to remove the need to explicitly end each test
- new sqlmap tests to check that quoteIdent is safe
- docker-compose file setting up the db to make it easier to run security tests locally