### PR TITLE
Use a SqlStatement within template literal

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,16 @@ A simple SQL injection protection module that allows you to use ES6 template str
 2. [Usage](#usage)
    1. [Linting](#linting)
 3. [Methods](#methods)
-   1. [append](#appendstatement)
-   2. [glue](#gluepieces-separator)
-4. [How it works?](#how-it-works)
-5. [Undefined values and nullable fields](#undefined-values-and-nullable-fields)
-6. [Testing, linting, & coverage](#testing-linting--coverage)
-7. [Benchmark](#benchmark)
-8. [License](#license)
+   1. [glue](#gluepieces-separator)
+   2. (deprecated) [append](#deprecated-appendstatement-options)
+4. [Utilities](#utilities)
+   1. [unsafe](#unsafevalue)
+   2. [quoteIdent](#quoteidentvalue)
+5. [How it works?](#how-it-works)
+6. [Undefined values and nullable fields](#undefined-values-and-nullable-fields)
+7. [Testing, linting, & coverage](#testing-linting--coverage)
+8. [Benchmark](#benchmark)
+9. [License](#license)
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Append has been deprecated in favour of using template literals:
 
 ```js
 const from = SQL`FROM table`
-const sql = SQL`SELECT * ${forma}`
+const sql = SQL`SELECT * ${from}`
 ```
 
 For now, you can still use append as follows:

--- a/README.md
+++ b/README.md
@@ -58,18 +58,6 @@ sql`SELECT 1`
 
 ## Methods
 
-### append(statement[, options])
-
-```js
-const username = 'user1'
-const email = 'user1@email.com'
-const userId = 1
-
-const sql = SQL`UPDATE users SET name = ${username}, email = ${email}`
-sql.append(SQL`, ${dynamicName} = 'dynamicValue'`, { unsafe: true })
-sql.append(SQL`WHERE id = ${userId}`)
-```
-
 > ⚠️ **Warning**
 >
 > The `unsafe` option interprets the interpolated values as literals and it should be used carefully to avoid introducing SQL injection vulnerabilities.
@@ -81,14 +69,11 @@ const username = 'user1'
 const email = 'user1@email.com'
 const userId = 1
 
-const sql = SQL` UPDATE users SET `
-
 const updates = []
 updates.push(SQL`name = ${username}`)
 updates.push(SQL`email = ${email}`)
 
-sql.append(sql.glue(updates, ' , '))
-sql.append(SQL`WHERE id = ${userId}`)
+const sql = SQL`UPDATE users SET ${SQL.glue(updates, ' , ')} WHERE id = ${userId}`
 ```
 
 or also
@@ -96,13 +81,12 @@ or also
 ```js
 const ids = [1, 2, 3]
 const value = 'test'
-const sql = SQL` UPDATE users SET property = ${value}`
-
-const idsSqls = ids.map(id => SQL`${id}`)
-
-sql.append(SQL`WHERE id IN (`)
-sql.append(sql.glue(idsSqls, ' , '))
-sql.append(SQL`)`)
+const sql = SQL`
+UPDATE users
+SET property = ${value}
+WHERE id
+IN (${SQL.glue(ids.map(id => SQL`${id}`), ' , ')})
+`
 ```
 
 Glue can also be used statically:
@@ -122,14 +106,33 @@ const users = [
   { id: 3, name: 'something-other' }
 ]
 
-const sql = SQL`INSERT INTO users (id, name) VALUES `
-
-sql.append(
-  SQL.glue(
+const sql = SQL`INSERT INTO users (id, name) VALUES 
+  ${SQL.glue(
     users.map(user => SQL`(${user.id},${user.name}})`),
     ' , '
-  )
-)
+  )}
+`
+```
+
+### (deprecated) append(statement[, options])
+
+Append has been deprecated in favour of using template literals:
+
+```js
+const from = SQL`FROM table`
+const sql = SQL`SELECT * ${forma}`
+```
+
+For now, you can still use append as follows:
+
+```js
+const username = 'user1'
+const email = 'user1@email.com'
+const userId = 1
+
+const sql = SQL`UPDATE users SET name = ${username}, email = ${email}`
+sql.append(SQL`, ${dynamicName} = 'dynamicValue'`, { unsafe: true })
+sql.append(SQL`WHERE id = ${userId}`)
 ```
 
 ## Utilities

--- a/SQL.d.ts
+++ b/SQL.d.ts
@@ -44,12 +44,6 @@ declare class SqlStatement implements StatementLike {
    */
   static glue(pieces: StatementLike[], separator: string): SqlStatement
 
-  /**
-   * Generates a PostgreSQL or MySQL statement string from this statement's strings and values
-   * @param type the type of statement string to be generated
-   */
-  generateString(type?: 'pg' | 'mysql'): string
-
   /** Returns a formatted but unsafe statement of strings and values, useful for debugging */
   get debug(): string
 

--- a/SQL.d.ts
+++ b/SQL.d.ts
@@ -64,6 +64,7 @@ declare class SqlStatement implements StatementLike {
 
   /**
    * Appends another statement onto this statement
+   * @deprecated Please append within template literals, e.g. SQL`SELECT * ${sql}`
    * @param statement a statement to be appended onto this existing statement
    * @param options allows disabling the safe template escaping while appending
    * @example

--- a/SQL.js
+++ b/SQL.js
@@ -45,7 +45,7 @@ class SqlStatement {
     return new SqlStatement(result.strings, result.values)
   }
 
-  generateString (type, namedValueOffset = 0) {
+  _generateString (type, namedValueOffset = 0) {
     let text = this.strings[0]
     let valueOffset = 0
     const values = [...this._values]
@@ -59,7 +59,7 @@ class SqlStatement {
         values.splice(valueIndex, 1)
         valueOffset--
       } else if (valueContainer instanceof SqlStatement) {
-        text += `${valueContainer.generateString(type, valueIndex + namedValueOffset)}${this.strings[i]}`
+        text += `${valueContainer._generateString(type, valueIndex + namedValueOffset)}${this.strings[i]}`
         valueOffset += valueContainer.values.length - 1
         values.splice(valueIndex, 1, ...valueContainer.values)
       } else {
@@ -100,11 +100,11 @@ class SqlStatement {
   }
 
   get text () {
-    return this.generateString('pg')
+    return this._generateString('pg')
   }
 
   get sql () {
-    return this.generateString('mysql')
+    return this._generateString('mysql')
   }
 
   get values () {

--- a/SQL.js
+++ b/SQL.js
@@ -47,8 +47,9 @@ class SqlStatement {
 
   generateString (type, namedValueOffset = 0) {
     let text = this.strings[0]
-    const values = [...this._values]
     let valueOffset = 0
+    const values = [...this._values]
+    
     for (let i = 1; i < this.strings.length; i++) {
       const valueIndex = i - 1 + valueOffset
       const valueContainer = values[valueIndex]

--- a/SQL.js
+++ b/SQL.js
@@ -57,7 +57,7 @@ class SqlStatement {
         text += `${valueContainer.transform(type)}${this.strings[i]}`
         values.splice(valueIndex, 1)
         valueOffset--
-      } else if (valueContainer && valueContainer instanceof SqlStatement) {
+      } else if (valueContainer instanceof SqlStatement) {
         text += `${valueContainer.generateString(type, valueIndex)}${this.strings[i]}`
         valueOffset += valueContainer.values.length - 1
         values.splice(valueIndex, 1, ...valueContainer.values)
@@ -84,7 +84,7 @@ class SqlStatement {
         data = data.transform()
         quote = ''
       }
-      if (data && data instanceof SqlStatement) {
+      if (data instanceof SqlStatement) {
         data = data.debug
         quote = ''
       }
@@ -109,7 +109,7 @@ class SqlStatement {
 
   get values () {
     return this._values.filter(v => !v || !v[wrapped]).reduce((acc, v) => {
-      if (v && v instanceof SqlStatement) {
+      if (v instanceof SqlStatement) {
         return [...acc, ...v.values]
       }
       return [...acc, v]

--- a/SQL.js
+++ b/SQL.js
@@ -110,9 +110,11 @@ class SqlStatement {
   get values () {
     return this._values.filter(v => !v || !v[wrapped]).reduce((acc, v) => {
       if (v instanceof SqlStatement) {
-        return [...acc, ...v.values]
+        acc.push(...v.values)
+      } else {
+        acc.push(v)
       }
-      return [...acc, v]
+      return acc
     }, [])
   }
 

--- a/SQL.js
+++ b/SQL.js
@@ -49,7 +49,7 @@ class SqlStatement {
     let text = this.strings[0]
     let valueOffset = 0
     const values = [...this._values]
-    
+
     for (let i = 1; i < this.strings.length; i++) {
       const valueIndex = i - 1 + valueOffset
       const valueContainer = values[valueIndex]

--- a/SQL.js
+++ b/SQL.js
@@ -1,7 +1,7 @@
 'use strict'
 const inspect = Symbol.for('nodejs.util.inspect.custom')
 const wrapped = Symbol('wrapped')
-const SQLSymbol = Symbol('SQL')
+const SqlStatementSymbol = Symbol('SQL')
 
 const quoteIdentifier = require('./quoteIdentifier')
 
@@ -58,7 +58,7 @@ class SqlStatement {
         text += `${valueContainer.transform(type)}${this.strings[i]}`
         values.splice(valueIndex, 1)
         valueOffset--
-      } else if (valueContainer && valueContainer[SQLSymbol]) {
+      } else if (valueContainer && valueContainer[SqlStatementSymbol]) {
         text += `${valueContainer.generateString(type, i + valueOffset - 1)}${this.strings[i]}`
         valueOffset += valueContainer.values.length - 1
         values.splice(valueIndex, 1, ...valueContainer.values)
@@ -85,7 +85,7 @@ class SqlStatement {
         data = data.transform()
         quote = ''
       }
-      if (data && data[SQLSymbol]) {
+      if (data && data[SqlStatementSymbol]) {
         data = data.debug
         quote = ''
       }
@@ -147,7 +147,7 @@ class SqlStatement {
     return this
   }
 
-  [SQLSymbol] = true
+  [SqlStatementSymbol] = true
 }
 
 function SQL (strings, ...values) {

--- a/SQL.js
+++ b/SQL.js
@@ -152,7 +152,7 @@ class SqlStatement {
     return this
   }
 
-  [SqlStatementSymbol] = true
+  get [SqlStatementSymbol] () { return true }
 }
 
 function SQL (strings, ...values) {

--- a/SQL.js
+++ b/SQL.js
@@ -45,12 +45,12 @@ class SqlStatement {
     return new SqlStatement(result.strings, result.values)
   }
 
-  generateString (type, initialValueOffset = 0) {
+  generateString (type, namedValueOffset = 0) {
     let text = this.strings[0]
     const values = [...this._values]
-    let valueOffset = initialValueOffset
+    let valueOffset = 0
     for (let i = 1; i < this.strings.length; i++) {
-      const valueIndex = i - 1 + valueOffset - initialValueOffset
+      const valueIndex = i - 1 + valueOffset
       const valueContainer = values[valueIndex]
 
       if (valueContainer && valueContainer[wrapped]) {
@@ -58,13 +58,13 @@ class SqlStatement {
         values.splice(valueIndex, 1)
         valueOffset--
       } else if (valueContainer instanceof SqlStatement) {
-        text += `${valueContainer.generateString(type, valueIndex + initialValueOffset)}${this.strings[i]}`
+        text += `${valueContainer.generateString(type, valueIndex + namedValueOffset)}${this.strings[i]}`
         valueOffset += valueContainer.values.length - 1
         values.splice(valueIndex, 1, ...valueContainer.values)
       } else {
         let delimiter = '?'
         if (type === 'pg') {
-          delimiter = '$' + (i + valueOffset)
+          delimiter = '$' + (i + valueOffset + namedValueOffset)
         }
 
         text += delimiter + this.strings[i]

--- a/SQL.js
+++ b/SQL.js
@@ -45,12 +45,12 @@ class SqlStatement {
     return new SqlStatement(result.strings, result.values)
   }
 
-  generateString (type, valueOffset = 0) {
+  generateString (type, initialValueOffset = 0) {
     let text = this.strings[0]
     const values = [...this._values]
-
+    let valueOffset = initialValueOffset
     for (let i = 1; i < this.strings.length; i++) {
-      const valueIndex = i - 1 + valueOffset
+      const valueIndex = i - 1 + valueOffset - initialValueOffset
       const valueContainer = values[valueIndex]
 
       if (valueContainer && valueContainer[wrapped]) {
@@ -58,7 +58,7 @@ class SqlStatement {
         values.splice(valueIndex, 1)
         valueOffset--
       } else if (valueContainer instanceof SqlStatement) {
-        text += `${valueContainer.generateString(type, valueIndex)}${this.strings[i]}`
+        text += `${valueContainer.generateString(type, valueIndex + initialValueOffset)}${this.strings[i]}`
         valueOffset += valueContainer.values.length - 1
         values.splice(valueIndex, 1, ...valueContainer.values)
       } else {

--- a/SQL.js
+++ b/SQL.js
@@ -84,8 +84,7 @@ class SqlStatement {
       if (data && data[wrapped]) {
         data = data.transform()
         quote = ''
-      }
-      if (data instanceof SqlStatement) {
+      } else if (data instanceof SqlStatement) {
         data = data.debug
         quote = ''
       }

--- a/SQL.js
+++ b/SQL.js
@@ -109,7 +109,12 @@ class SqlStatement {
   }
 
   get values () {
-    return this._values.filter(v => !v || !v[wrapped])
+    return this._values.filter(v => !v || !v[wrapped]).reduce((acc, v) => {
+      if (v && v[SqlStatementSymbol]) {
+        return [...acc, ...v.values]
+      }
+      return [...acc, v]
+    }, [])
   }
 
   append (statement, options) {

--- a/SQL.js
+++ b/SQL.js
@@ -116,6 +116,9 @@ class SqlStatement {
     }, [])
   }
 
+  /**
+   * @deprecated Please append within template literals, e.g. SQL`SELECT * ${sql}`
+   */
   append (statement, options) {
     if (!statement) {
       return this

--- a/SQL.test.js
+++ b/SQL.test.js
@@ -444,22 +444,22 @@ test('should be able to append within template literal', t => {
   )
   t.equal(
     selectWithLiteralExpression.debug,
-    `SELECT * FROM table`
+    'SELECT * FROM table'
   )
   t.end()
 })
 
 test('should be able to use sql within template literal', t => {
   const pre = 'A'
-  const ids = [ 1, '2', 'three' ]
+  const ids = [1, '2', 'three']
   const idValues = ids.map(id => SQL`${id}`)
-  const names = [ 'Bee', 'Cee', 'Dee' ]
+  const names = ['Bee', 'Cee', 'Dee']
   const nameValues = names.map(name => SQL`${name}`)
   const post = 'B'
   const sql = SQL`UPDATE my_table SET active = FALSE WHERE pre=${pre} AND id IN (${SQL.glue(idValues, ',')}) AND name IN (${SQL.glue(nameValues, ',')}) AND post=${post}`
   t.equal(
     sql.text,
-    `UPDATE my_table SET active = FALSE WHERE pre=$1 AND id IN ($2,$3,$4) AND name IN ($5,$6,$7) AND post=$8`
+    'UPDATE my_table SET active = FALSE WHERE pre=$1 AND id IN ($2,$3,$4) AND name IN ($5,$6,$7) AND post=$8'
   )
   t.same(
     sql.values,

--- a/SQL.test.js
+++ b/SQL.test.js
@@ -500,3 +500,58 @@ test('should be able to use nested SQLStatements in template literal', t => {
   )
   t.end()
 })
+
+test('examples in the readme work as expected', t => {
+  {
+    const username = 'user1'
+    const email = 'user1@email.com'
+    const userId = 1
+
+    const updates = []
+    updates.push(SQL`name = ${username}`)
+    updates.push(SQL`email = ${email}`)
+
+    const sql = SQL`UPDATE users SET ${SQL.glue(updates, ' , ')} WHERE id = ${userId}`
+    t.equal(
+      sql.text,
+      'UPDATE users SET name = $1 , email = $2 WHERE id = $3'
+    )
+  }
+  {
+    const ids = [1, 2, 3]
+    const value = 'test'
+    const sql = SQL`
+      UPDATE users
+      SET property = ${value}
+      WHERE id
+      IN (${SQL.glue(ids.map(id => SQL`${id}`), ' , ')})
+    `
+    t.equal(
+      sql.text,
+      `UPDATE users
+SET property = $1
+WHERE id
+IN ($2 , $3 , $4)`)
+  }
+
+  {
+    const users = [
+      { id: 1, name: 'something' },
+      { id: 2, name: 'something-else' },
+      { id: 3, name: 'something-other' }
+    ]
+
+    const sql = SQL`INSERT INTO users (id, name) VALUES 
+      ${SQL.glue(
+        users.map(user => SQL`(${user.id},${user.name}})`),
+        ' , '
+      )}
+    `
+    t.equal(
+      sql.text,
+      `INSERT INTO users (id, name) VALUES
+($1,$2}) , ($3,$4}) , ($5,$6})`
+    )
+  }
+  t.end()
+})

--- a/SQL.test.js
+++ b/SQL.test.js
@@ -461,6 +461,14 @@ test('should be able to use SQL.glue within template literal', t => {
     sql.text,
     'UPDATE my_table SET active = FALSE WHERE pre=$1 AND id IN ($2,$3,$4) AND name IN ($5,$6,$7) AND post=$8'
   )
+  t.equal(
+    sql.sql,
+    'UPDATE my_table SET active = FALSE WHERE pre=? AND id IN (?,?,?) AND name IN (?,?,?) AND post=?'
+  )
+  t.equal(
+    sql.debug,
+    'UPDATE my_table SET active = FALSE WHERE pre=\'A\' AND id IN (1,\'2\',\'three\') AND name IN (\'Bee\',\'Cee\',\'Dee\') AND post=\'B\''
+  )
   t.same(
     sql.values,
     ['A', 1, '2', 'three', 'Bee', 'Cee', 'Dee', 'B']
@@ -477,6 +485,14 @@ test('should be able to use nested SQLStatements in template literal', t => {
   t.equal(
     sql.text,
     'UPDATE my_table SET active = FALSE WHERE a=$1 AND b=$2 AND c=$3 AND d=$4'
+  )
+  t.equal(
+    sql.sql,
+    'UPDATE my_table SET active = FALSE WHERE a=? AND b=? AND c=? AND d=?'
+  )
+  t.equal(
+    sql.debug,
+    'UPDATE my_table SET active = FALSE WHERE a=\'A\' AND b=\'B\' AND c=\'C\' AND d=\'D\''
   )
   t.same(
     sql.values,

--- a/SQL.test.js
+++ b/SQL.test.js
@@ -430,7 +430,7 @@ test('should be able to append query that is using "quoteIdent(...)"', async t =
   t.same(sql.values, [id])
 })
 
-test('should be able to append within template literal', { only: true }, t => {
+test('should be able to append within template literal', t => {
   const a = SQL`FROM table`
   const selectWithLiteralExpression = SQL`SELECT * ${a}`
 

--- a/SQL.test.js
+++ b/SQL.test.js
@@ -429,3 +429,41 @@ test('should be able to append query that is using "quoteIdent(...)"', async t =
   )
   t.same(sql.values, [id])
 })
+
+test('should be able to append within template literal', { only: true }, t => {
+  const a = SQL`FROM table`
+  const selectWithLiteralExpression = SQL`SELECT * ${a}`
+
+  t.equal(
+    selectWithLiteralExpression.text,
+    'SELECT * FROM table'
+  )
+  t.equal(
+    selectWithLiteralExpression.sql,
+    'SELECT * FROM table'
+  )
+  t.equal(
+    selectWithLiteralExpression.debug,
+    `SELECT * FROM table`
+  )
+  t.end()
+})
+
+test('should be able to use sql within template literal', t => {
+  const pre = 'A'
+  const ids = [ 1, '2', 'three' ]
+  const idValues = ids.map(id => SQL`${id}`)
+  const names = [ 'Bee', 'Cee', 'Dee' ]
+  const nameValues = names.map(name => SQL`${name}`)
+  const post = 'B'
+  const sql = SQL`UPDATE my_table SET active = FALSE WHERE pre=${pre} AND id IN (${SQL.glue(idValues, ',')}) AND name IN (${SQL.glue(nameValues, ',')}) AND post=${post}`
+  t.equal(
+    sql.text,
+    `UPDATE my_table SET active = FALSE WHERE pre=$1 AND id IN ($2,$3,$4) AND name IN ($5,$6,$7) AND post=$8`
+  )
+  t.same(
+    sql.values,
+    ['A', 1, '2', 'three', 'Bee', 'Cee', 'Dee', 'B']
+  )
+  t.end()
+})

--- a/SQL.test.js
+++ b/SQL.test.js
@@ -430,7 +430,7 @@ test('should be able to append query that is using "quoteIdent(...)"', async t =
   t.same(sql.values, [id])
 })
 
-test('should be able to append within template literal', t => {
+test('should be able to append a SqlStatement within a template literal', t => {
   const a = SQL`FROM table`
   const selectWithLiteralExpression = SQL`SELECT * ${a}`
 
@@ -449,7 +449,7 @@ test('should be able to append within template literal', t => {
   t.end()
 })
 
-test('should be able to use sql within template literal', t => {
+test('should be able to use SQL.glue within template literal', t => {
   const pre = 'A'
   const ids = [1, '2', 'three']
   const idValues = ids.map(id => SQL`${id}`)

--- a/SQL.test.js
+++ b/SQL.test.js
@@ -467,3 +467,20 @@ test('should be able to use SQL.glue within template literal', t => {
   )
   t.end()
 })
+
+test('should be able to use nested SQLStatements in template literal', t => {
+  const a = 'A'
+  const b = 'B'
+  const c = 'C'
+  const d = 'D'
+  const sql = SQL`UPDATE my_table SET active = FALSE WHERE a=${a} AND ${SQL`b=${b} AND ${SQL`c=${c}`}`} AND d=${d}`
+  t.equal(
+    sql.text,
+    'UPDATE my_table SET active = FALSE WHERE a=$1 AND b=$2 AND c=$3 AND d=$4'
+  )
+  t.same(
+    sql.values,
+    ['A', 'B', 'C', 'D']
+  )
+  t.end()
+})


### PR DESCRIPTION
- Use a SqlStatement within template literal, e.g. the output of `SQL.glue` or another use of SQL``
- Deprecate .append in favour of nested template literals
- Clarifications that generateString is not part of the public API

Fixes #51 