### PR TITLE
Fix: glue with nested multi values

### DIFF
--- a/SQL.js
+++ b/SQL.js
@@ -17,28 +17,19 @@ class SqlStatement {
 
   glue (pieces, separator) {
     const result = { strings: [], values: [] }
-
     let carryover
     for (let i = 0; i < pieces.length; i++) {
       const strings = Array.from(pieces[i].strings)
-      if (typeof carryover === 'string') {
+      if (i > 0) {
         strings[0] = carryover + separator + strings[0]
         carryover = null
       }
-
-      if (strings.length > pieces[i].values.length) {
-        carryover = strings.splice(-1)[0]
-      }
+      carryover = strings.splice(-1)[0]
       result.strings.push.apply(result.strings, strings)
       result.values.push.apply(result.values, pieces[i]._values)
     }
-    if (typeof carryover === 'string') {
-      result.strings.push(carryover)
-    }
 
-    if (result.strings.length === result.values.length) {
-      result.strings.push('')
-    }
+    result.strings.push(carryover)
 
     result.strings[result.strings.length - 1] += ' '
 

--- a/SQL.js
+++ b/SQL.js
@@ -22,7 +22,6 @@ class SqlStatement {
       const strings = Array.from(pieces[i].strings)
       if (i > 0) {
         strings[0] = carryover + separator + strings[0]
-        carryover = null
       }
       carryover = strings.splice(-1)[0]
       result.strings.push.apply(result.strings, strings)

--- a/SQL.test.js
+++ b/SQL.test.js
@@ -518,7 +518,11 @@ test('should be able to use the result of SQL.glue([SQL``, SQL``], separator) re
     'SELECT tsd.* FROM data tsd WHERE tsd.id IN ($1 , $2 , $3) AND tsd.name = $4'
   )
   t.same(
-    sql.values, [1,2,3, "foo"]
+    sql.values, [1, 2, 3, 'foo']
+  )
+  t.equal(
+    sql.debug,
+    "SELECT tsd.* FROM data tsd WHERE tsd.id IN (1 , 2 , 3) AND tsd.name = 'foo'"
   )
   t.end()
 })

--- a/SQL.test.js
+++ b/SQL.test.js
@@ -506,28 +506,6 @@ test('should be able to use the result of SQL.glue([SQL``, SQL``], separator) re
     ' , '
   )
   const condition = SQL`tsd.id IN (${inIds})`
-  // this condition results in:
-  // {
-  //     "strings": [
-  //         "tsd.id IN (",
-  //         ")"
-  //     ],
-  //     "_values": [
-  //         {
-  //             "strings": [
-  //                 "",
-  //                 " , ",
-  //                 " , ",
-  //                 " "
-  //             ],
-  //             "_values": [
-  //                 1,
-  //                 2,
-  //                 3
-  //             ]
-  //         }
-  //     ]
-  // }
 
   const filters = [
     condition,

--- a/SQL.test.js
+++ b/SQL.test.js
@@ -517,6 +517,9 @@ test('should be able to use the result of SQL.glue([SQL``, SQL``], separator) re
     sql.text,
     'SELECT tsd.* FROM data tsd WHERE tsd.id IN ($1 , $2 , $3) AND tsd.name = $4'
   )
+  t.same(
+    sql.values, [1,2,3, "foo"]
+  )
   t.end()
 })
 


### PR DESCRIPTION
Fixes #94 

In this issue, we catch a bug when one of the arguments, except the last one in SQL.glue(args) has nested values.
Example:
```
const ids = [1, 2, 3]
const name = 'foo'
const moreIds = [4, 5, 6]
const inIds = SQL.glue(
  ids.map((id) => SQL`${id}`),
  ' , '
)
const inMoreIds = SQL.glue(
  moreIds.map((id) => SQL`${id}`),
  ' , '
)
const condition = SQL`tsd.id IN (${inIds})`
const anotherCondition = SQL`tsd.id IN (${inIds})`

//this works because the nested condition is the last one
// const filters = [
//   SQL`tsd.name = ${name}`,
//   condition,
// ]

// Error, result is SELECT tsd.* FROM data tsd WHERE tsd.id IN (? , ? , ?)?tsd.name = ?
const filters = [
  condition,
  SQL`tsd.name = ${name}`,
]

// Error, result is SELECT tsd.* FROM data tsd WHERE tsd.name = ? AND tsd.id IN (? , ? , ?) ?, ?, ?tsd.in (?)
// const filters = [
//   SQL`tsd.name = ${name}`,
//   condition,
//   anotherCondition
// ]

const sql = SQL`SELECT tsd.* FROM data tsd WHERE ${SQL.glue(filters, ' AND ')}`

```

the cause is in this piece of code
```
    for (let i = 0; i < pieces.length; i++) {
      const strings = Array.from(pieces[i].strings)
      if (typeof carryover === 'string') {
        strings[0] = carryover + separator + strings[0]
        carryover = null
      }

      if (strings.length > pieces[i].values.length) {
        carryover = strings.splice(-1)[0]
      }
      result.strings.push.apply(result.strings, strings)
      result.values.push.apply(result.values, pieces[i]._values)
    }
```
In the second if "strings.length > pieces[i].values.length" we check if strings.length if higher than pieces[I].values.length, and only if this condition is true we change the value of carryover variable, but we only add the separator if the variable carryover type is a string. 

So every time that one of the pieces (except the last one because we don't need the separator in this case) doesn't match with the second "if" we will not have the addition of the separator.
