### PR TITLE
108: added support for value arrays when working with objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A simple SQL injection protection module that allows you to use ES6 template str
    1. [Linting](#linting)
 3. [Methods](#methods)
    1. [glue](#gluepieces-separator)
+   2. [map](#map)
    2. (deprecated) [append](#deprecated-appendstatement-options)
 4. [Utilities](#utilities)
    1. [unsafe](#unsafevalue)
@@ -115,6 +116,40 @@ const sql = SQL`INSERT INTO users (id, name) VALUES
     ' , '
   )}
 `
+```
+
+### map(array, mapperFunction)
+
+Using the default mapperFunction which is just an iteration over the array elements
+```js
+const ids = [1, 2, 3]
+
+const values = SQL.map(ids)
+const sql = SQL`INSERT INTO users (id) VALUES (${values})`
+```
+
+Using an array of objects which requires a mapper function
+
+```js
+const objArray = [{
+  id: 1,
+  name: 'name1'
+},
+{
+  id: 2,
+  name: 'name2'
+},
+{
+  id: 3,
+  name: 'name3'
+}]
+
+const mapperFunction = (objItem) => {
+  return objItem.id
+}
+
+const values = SQL.map(objArray, mapperFunction)
+const sql = SQL`INSERT INTO users (id) VALUES (${values})`
 ```
 
 ### (deprecated) append(statement[, options])

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A simple SQL injection protection module that allows you to use ES6 template str
    1. [Linting](#linting)
 3. [Methods](#methods)
    1. [glue](#gluepieces-separator)
-   2. [map](#map)
+   2. [map](#maparray-mapperfunction)
    2. (deprecated) [append](#deprecated-appendstatement-options)
 4. [Utilities](#utilities)
    1. [unsafe](#unsafevalue)
@@ -144,11 +144,9 @@ const objArray = [{
   name: 'name3'
 }]
 
-const mapperFunction = (objItem) => {
-  return objItem.id
-}
-
+const mapperFunction = (objItem) => objItem.id
 const values = SQL.map(objArray, mapperFunction)
+
 const sql = SQL`INSERT INTO users (id) VALUES (${values})`
 ```
 

--- a/SQL.js
+++ b/SQL.js
@@ -35,6 +35,20 @@ class SqlStatement {
     return new SqlStatement(result.strings, result.values)
   }
 
+  /**
+   * A function that accepts an array of objects and a mapper function
+   * It returns a clean SQL format using the object properties defined in the mapper function
+   */
+  map (array, mapFunc) {
+    if ((mapFunc instanceof Function) && array && array.length > 0) {
+      return this.glue(
+        array.map(mapFunc).map((item) => SQL`${item}`),
+        ','
+      )
+    }
+    return null
+  }
+
   _generateString (type, namedValueOffset = 0) {
     let text = this.strings[0]
     let valueOffset = 0
@@ -157,6 +171,7 @@ function SQL (strings, ...values) {
 }
 
 SQL.glue = SqlStatement.prototype.glue
+SQL.map = SqlStatement.prototype.map
 
 module.exports = SQL
 module.exports.SQL = SQL

--- a/SQL.js
+++ b/SQL.js
@@ -40,7 +40,7 @@ class SqlStatement {
    * It returns a clean SQL format using the object properties defined in the mapper function
    */
   map (array, mapFunc) {
-    if ((mapFunc instanceof Function) && array && array.length > 0) {
+    if ((mapFunc instanceof Function) && array?.length > 0) {
       return this.glue(
         array.map(mapFunc).map((item) => SQL`${item}`),
         ','

--- a/SQL.js
+++ b/SQL.js
@@ -39,7 +39,7 @@ class SqlStatement {
    * A function that accepts an array of objects and a mapper function
    * It returns a clean SQL format using the object properties defined in the mapper function
    */
-  map (array, mapFunc) {
+  map (array, mapFunc = i => i) {
     if ((mapFunc instanceof Function) && array?.length > 0) {
       return this.glue(
         array.map(mapFunc).map((item) => SQL`${item}`),

--- a/SQL.test.js
+++ b/SQL.test.js
@@ -88,15 +88,15 @@ test('SQL helper - multiline with emtpy lines', async t => {
 test('SQL helper - build complex query with map', async t => {
   const objArray = [{
     id: 1,
-    name: 'name1',
+    name: 'name1'
   },
   {
     id: 2,
-    name: 'name2',
+    name: 'name2'
   },
   {
     id: 3,
-    name: 'name3',
+    name: 'name3'
   }]
 
   const mapFunction = (objItem) => {

--- a/SQL.test.js
+++ b/SQL.test.js
@@ -85,6 +85,56 @@ test('SQL helper - multiline with emtpy lines', async t => {
   t.same(sql.values, [name, description, teamId, organizationId])
 })
 
+test('SQL helper - build complex query with map', async t => {
+  const objArray = [{
+    id: 1,
+    name: 'name1',
+  },
+  {
+    id: 2,
+    name: 'name2',
+  },
+  {
+    id: 3,
+    name: 'name3',
+  }]
+
+  const mapFunction = (objItem) => {
+    return objItem.id
+  }
+
+  const values = SQL.map(objArray, mapFunction)
+  t.equal(values !== null, true)
+  const sql = SQL`INSERT INTO users (id) VALUES (${values})`
+
+  t.equal(sql.text, 'INSERT INTO users (id) VALUES ($1,$2,$3)')
+  t.equal(sql.sql, 'INSERT INTO users (id) VALUES (?,?,?)')
+  t.equal(sql.debug, 'INSERT INTO users (id) VALUES (1,2,3)')
+  t.same(sql.values, [1, 2, 3])
+})
+
+test('SQL helper - build complex query with map - empty array', async t => {
+  const objArray = []
+
+  const mapFunction = (objItem) => {
+    return objItem.id
+  }
+
+  const values = SQL.map(objArray, mapFunction)
+
+  t.equal(values, null)
+})
+
+test('SQL helper - build complex query with map - bad mapper function', async t => {
+  const objArray = []
+
+  const mapFunction = null
+
+  const values = SQL.map(objArray, mapFunction)
+
+  t.equal(values, null)
+})
+
 test('SQL helper - build complex query with glue', async t => {
   const name = 'Team 5'
   const description = 'description'

--- a/SQL.test.js
+++ b/SQL.test.js
@@ -113,6 +113,19 @@ test('SQL helper - build complex query with map', async t => {
   t.same(sql.values, [1, 2, 3])
 })
 
+test('SQL helper - build complex query with map - using default mapper function', async t => {
+  const ids = [1, 2, 3]
+
+  const values = SQL.map(ids)
+  t.equal(values !== null, true)
+  const sql = SQL`INSERT INTO users (id) VALUES (${values})`
+
+  t.equal(sql.text, 'INSERT INTO users (id) VALUES ($1,$2,$3)')
+  t.equal(sql.sql, 'INSERT INTO users (id) VALUES (?,?,?)')
+  t.equal(sql.debug, 'INSERT INTO users (id) VALUES (1,2,3)')
+  t.same(sql.values, [1, 2, 3])
+})
+
 test('SQL helper - build complex query with map - empty array', async t => {
   const objArray = []
 


### PR DESCRIPTION
- when working with arrays of objects, we should be able to create a clean SQL query using glue
- example of usage can be found in the SQL.test.js file
- closes #108 