### PR TITLE
Fix/131 update to python3

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "homepage": "https://github.com/nearform/sql#readme",
   "devDependencies": {
+    "@fastify/postgres": "^4.0.0",
     "async": "^3.2.0",
     "benchmark": "^2.1.4",
     "fastify": "^4.0.1",
@@ -33,8 +34,7 @@
     "sql-template-strings": "^2.2.2",
     "standard": "^17.0.0",
     "tap": "^16.0.0",
-    "tsd": "^0.25.0",
-    "@fastify/postgres": "^4.0.0"
+    "tsd": "^0.25.0"
   },
   "standard": {
     "ignore": [

--- a/package.json
+++ b/package.json
@@ -27,14 +27,14 @@
     "async": "^3.2.0",
     "benchmark": "^2.1.4",
     "fastify": "^4.0.1",
-    "fastify-postgres": "^3.1.0",
     "jsonfile": "^6.1.0",
     "napa": "^3.0.0",
     "pg": "^8.6.0",
     "sql-template-strings": "^2.2.2",
     "standard": "^17.0.0",
     "tap": "^16.0.0",
-    "tsd": "^0.25.0"
+    "tsd": "^0.25.0",
+    "@fastify/postgres": "^4.0.0"
   },
   "standard": {
     "ignore": [

--- a/sqlmap/server.js
+++ b/sqlmap/server.js
@@ -5,13 +5,13 @@ const fastify = require('fastify')({
   logger: false
 })
 
-fastify.register(require('fastify-postgres'), require('./config'))
+fastify.register(require('@fastify/postgres'), require('./config'))
 fastify.register(users)
 fastify.register(table)
 
 const start = async () => {
   try {
-    await fastify.listen(8080)
+    await fastify.listen({ port: 8080 })
     // it's important to write to stdout as the sqlmap script relies on
     // a message from the server to be printed on stdout to start the checks
     console.log('Server started')

--- a/sqlmap/sqlmap.js
+++ b/sqlmap/sqlmap.js
@@ -13,14 +13,14 @@ if (!endpoints) {
   process.exit(1)
 }
 
-const findPython2 = (pythonCommand, done) => {
+const findPython3 = (pythonCommand, done) => {
   return exec(`${pythonCommand} --version`, function (err, stdout, stderr) {
     if (err) {
       return done(err)
     }
 
-    if (stderr.indexOf('Python 2.') >= 0) {
-      console.log(chalk.green(`✅  '${pythonCommand}' is a valid Python2`))
+    if (stdout.indexOf('Python 3.') >= 0) {
+      console.log(chalk.green(`✅  '${pythonCommand}' is a valid Python3`))
       return done(null, pythonCommand)
     }
     return done(null, false)
@@ -119,7 +119,7 @@ fastify.stderr.on('data', data => {
   console.log(`${fastifyChalk} ${chalk.red(data)}`)
 })
 
-async.detect(['python2', 'python'], findPython2, function (err, python) {
+async.detect(['python3'], findPython3, function (err, python) {
   if (err) {
     return console.error(chalk.red(err))
   }


### PR DESCRIPTION
It closes #131 

### Main changes:
- update python from version 2 to 3
- update fastify-postgres dependency to use the renamed package @fastify/postgres
- update fastify.listen method to use options object

### Tests

- I tested locally with a fork repo the CI action and is now working