### PR TITLE
fix: add `map` to the ts definitions file

### DIFF
--- a/SQL.d.ts
+++ b/SQL.d.ts
@@ -44,6 +44,30 @@ declare class SqlStatement implements StatementLike {
    */
   static glue(pieces: StatementLike[], separator: string): SqlStatement
 
+  /**
+   * A function that accepts an array of objects and a mapper function
+   * It returns a clean SQL format using the object properties defined in the mapper function
+   * @param array the items to be mapped over
+   * @param mapFunc a function to transform the items in `array` before being added to the SqlStatement
+   * @example
+   * SQL`SELECT ${SQL.map([1,2,3])}`
+   * @example
+   * SQL`SELECT ${SQL.map([1,2,3], x => x ** 2)}`
+   */
+  map<T>(array: T[], mapFunc?: (item: T) => unknown): SqlStatement
+
+  /**
+   * A function that accepts an array of objects and a mapper function
+   * It returns a clean SQL format using the object properties defined in the mapper function
+   * @param array the items to be mapped over
+   * @param mapFunc a function to transform the items in `array` before being added to the SqlStatement
+   * @example
+   * SQL`SELECT ${SQL.map([1,2,3])}`
+   * @example
+   * SQL`SELECT ${SQL.map([1,2,3], x => x ** 2)}`
+   */
+  static map<T>(array: T[], mapFunc?: (item: T) => unknown): SqlStatement
+
   /** Returns a formatted but unsafe statement of strings and values, useful for debugging */
   get debug(): string
 
@@ -84,6 +108,18 @@ declare namespace SQL {
    * )
    */
   export function glue(pieces: StatementLike[], separator: string): SqlStatement
+
+  /**
+   * A function that accepts an array of objects and a mapper function
+   * It returns a clean SQL format using the object properties defined in the mapper function
+   * @param array the items to be mapped over
+   * @param mapFunc a function to transform the items in `array` before being added to the SqlStatement
+   * @example
+   * SQL`SELECT ${SQL.map([1,2,3])}`
+   * @example
+   * SQL`SELECT ${SQL.map([1,2,3], x => x ** 2)}`
+   */
+  export function map<T>(array: T[], mapFunc?: (item: T) => unknown): SqlStatement
 
   export function unsafe<T>(value: T): { value: T }
   export function quoteIdent(value: string): { value: string }

--- a/SQL.test-d.ts
+++ b/SQL.test-d.ts
@@ -1,5 +1,5 @@
 import SQL from '.'
-import { glue, SqlStatement } from '.'
+import { glue, map, SqlStatement } from '.'
 import { expectType, expectError } from 'tsd'
 
 expectType<SqlStatement>(SQL`SELECT 1`)
@@ -8,6 +8,10 @@ expectType<SqlStatement>(SQL`SELECT `.append(SQL`1`))
 expectType<SQL.SqlStatement>(SQL`SELECT `.append(SQL`1`))
 expectType<SqlStatement>(glue([SQL`SELECT`, SQL`1`], ' '))
 expectType<SQL.SqlStatement>(SQL.glue([SQL`SELECT`, SQL`1`], ' '))
+expectType<SQL.SqlStatement>(SQL.map([1,2,3]))
+expectType<SQL.SqlStatement>(SQL.map([1,2,3], x => x**2))
+expectType<SQL.SqlStatement>(map([1,2,3]))
+expectType<SQL.SqlStatement>(map([1,2,3], x => x**2))
 expectType<string>(SQL`SELECT 1`.debug)
 expectType<string>(SQL`SELECT 1`.sql)
 expectType<string>(SQL`SELECT 1`.text)


### PR DESCRIPTION
Closes #163

Adds typescript definitions for the `map` function