### PR TITLE
chore: upgrade deps and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,15 @@ jobs:
           - 24
         os:
           - ubuntu-latest
+        postgres-version:
+          - 14
+          - 15
+          - 16
+          - 17
+          - 18
     services:
       postgres:
-        image: postgres:9-alpine
+        image: postgres:${{ matrix.postgres-version }}-alpine
         env:
           POSTGRES_PASSWORD: postgres
           POSTGRES_USER: postgres

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
           - 16
           - 17
           - 18
+    name: "Node ${{ matrix.node-version }} - PostgreSQL ${{ matrix.postgres-version }}"
     services:
       postgres:
         image: postgres:${{ matrix.postgres-version }}-alpine

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "posttest": "tsd",
     "test:security": "node ./sqlmap/sqlmap.js",
     "test:typescript": "tsd",
-    "pretest:security": "napa https://github.com/sqlmapproject/sqlmap && node ./sqlmap/db-init.js",
+    "pretest:security": "git clone --depth=1 https://github.com/sqlmapproject/sqlmap node_modules/sqlmap && node ./sqlmap/db-init.js",
     "lint": "standard",
     "benchmark": "node benchmark/index.js"
   },
@@ -24,15 +24,14 @@
   },
   "homepage": "https://github.com/nearform/sql#readme",
   "devDependencies": {
-    "@fastify/postgres": "^5.2.0",
-    "async": "^3.2.0",
+    "@fastify/postgres": "^6.0.2",
+    "async": "^3.2.6",
     "benchmark": "^2.1.4",
-    "fastify": "^4.0.1",
-    "jsonfile": "^6.1.0",
-    "napa": "^3.0.0",
-    "pg": "^8.6.0",
+    "fastify": "^5.8.5",
+    "jsonfile": "^6.2.1",
+    "pg": "^8.20.0",
     "sql-template-strings": "^2.2.2",
-    "standard": "^17.0.0",
+    "standard": "^17.1.2",
     "tsd": "^0.33.0"
   },
   "standard": {


### PR DESCRIPTION
This pull request updates the CI configuration and development dependencies to support newer versions of PostgreSQL and to keep dependencies up to date. It also updates the way the `sqlmap` repository is cloned for security tests.

**CI/CD improvements:**

* Updated `.github/workflows/ci.yml` to run tests against PostgreSQL versions 14, 15, 16, 17, and 18, instead of a single old version, ensuring compatibility with newer database releases.

**Dependency updates:**

* Upgraded several development dependencies in `package.json`, including `@fastify/postgres`, `async`, `fastify`, `jsonfile`, `pg`, and `standard`, to their latest versions for improved performance and security.

**Security testing improvements:**

* Replaced the use of `napa` with a direct `git clone` for fetching the `sqlmap` repository in the `pretest:security` script, simplifying dependency management.